### PR TITLE
fix(ci): move dist-workspace.toml to repo root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ on:
     paths:
       - "crates/**"
       - "dist-workspace.toml"
-      - ".github/workflows/release-scute.yml"
+      - ".github/workflows/release.yml"
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
@@ -83,7 +83,7 @@ jobs:
         env:
           DIST_CMD: ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }}
         run: |
-          dist ${DIST_CMD} --output-format=json > plan-dist-manifest.json
+          dist ${DIST_CMD} --allow-dirty --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -151,7 +151,7 @@ jobs:
           DIST_ARGS: ${{ matrix.dist_args }}
         run: |
           # Actually do builds and make zips and whatnot
-          dist build ${TAG_FLAG} --print=linkage --output-format=json ${DIST_ARGS} > dist-manifest.json
+          dist build ${TAG_FLAG} --allow-dirty --print=linkage --output-format=json ${DIST_ARGS} > dist-manifest.json
           echo "dist ran successfully"
       - id: cargo-dist
         name: Post-build
@@ -206,7 +206,7 @@ jobs:
         env:
           TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}
         run: |
-          dist build ${TAG_FLAG} --output-format=json "--artifacts=global" > dist-manifest.json
+          dist build ${TAG_FLAG} --allow-dirty --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
 
           # Parse out what we just built and upload it to scratch storage
@@ -258,7 +258,7 @@ jobs:
         env:
           TAG_FLAG: ${{ needs.plan.outputs.tag-flag }}
         run: |
-          dist host ${TAG_FLAG} --steps=upload --steps=release --output-format=json > dist-manifest.json
+          dist host ${TAG_FLAG} --allow-dirty --steps=upload --steps=release --output-format=json > dist-manifest.json
           echo "artifacts uploaded and released successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -3,7 +3,7 @@ members = ["cargo:crates"]
 
 [dist]
 cargo-dist-version = "0.31.0"
-ci = []
+ci = "github"
 installers = ["shell", "powershell", "homebrew"]
 targets = [
   "aarch64-apple-darwin",

--- a/handbook/development.md
+++ b/handbook/development.md
@@ -42,7 +42,7 @@ Changes outside those paths (docs, handbook, etc.) don't trigger CI.
 2. release-plz detects releasable changes, opens a Release PR (bumps version in `Cargo.toml`)
 3. Review and merge the Release PR
 4. release-plz publishes to crates.io, creates a git tag (`v0.2.0`), and creates a draft GitHub Release with generated notes
-5. The tag triggers the `release-scute` workflow (cargo-dist)
+5. The tag triggers the `release` workflow (cargo-dist)
 6. cargo-dist builds binaries for 5 targets, attaches them to the GitHub Release, undrafts it, and pushes the Homebrew formula
 
 **Targets:** `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`


### PR DESCRIPTION
cargo-dist searches ancestors from the working directory, and CI runs from the repo root. Set ci=[] since we maintain the workflow ourselves (no config for custom workflow filenames yet).