### PR TITLE
fix(ci): use per-package git tags for release-plz

### DIFF
--- a/crates/release-plz.toml
+++ b/crates/release-plz.toml
@@ -3,9 +3,7 @@ changelog_update = false
 semver_check = false
 git_release_enable = true
 git_release_draft = true
-git_tag_name = "v{{ version }}"
 
-# Only create GitHub Releases for the CLI
 [[package]]
 name = "scute"
 git_release_enable = true


### PR DESCRIPTION
The shared v{{ version }} tag meant all crates resolved to the same v0.0.0 baseline, so release-plz couldn't track library crate changes independently. All crates now use package-prefixed tags so they can be versioned and tracked independently.