### PR TITLE
fix(ci): narrow release trigger to CLI crate and drop OpenMP dep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ on:
       - ".github/workflows/release.yml"
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - 'scute-v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -694,7 +694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec495a2918bacd868428951b45b9b3fb9464840e2ac559462c4370d6fa2c404"
 dependencies = [
  "cc",
- "openmp-sys",
 ]
 
 [[package]]
@@ -779,15 +778,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openmp-sys"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caef37114187ab867226e338413fb6cb23ccd785a63d4ee63e7335c88f1079e0"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "option-ext"

--- a/crates/scute-core/Cargo.toml
+++ b/crates/scute-core/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 ignore = "0.4.25"
-libsais = "0.2"
+libsais = { version = "0.2", default-features = false }
 minreq = { version = "2", features = ["https"] }
 semver = "1"
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

- Restrict the release workflow tag filter from `**[0-9]+.[0-9]+.[0-9]+*` to `scute-v[0-9]+.[0-9]+.[0-9]+*` so library crate tags don't trigger cargo-dist builds that can't succeed
- Disable OpenMP on `libsais` (`default-features = false`) since `omp.h` isn't available on macOS/aarch64-linux CI runners

Fixes the v0.0.1 release failures: 3 library crate tags failing with "release not found", and 3/5 binary builds failing on missing `omp.h`.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets`, `cargo test` all pass locally
- [ ] CI passes on this PR
- [ ] Next release tag push only triggers for `scute-v*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)