### PR TITLE
fix(ci): remove custom runner override for aarch64-linux

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,6 +17,3 @@ install-updater = false
 create-release = false
 tap = "scute-sh/homebrew-tap"
 publish-jobs = ["homebrew"]
-
-[dist.github-custom-runners]
-aarch64-unknown-linux-gnu = "ubuntu-latest"


### PR DESCRIPTION
## Summary

- Remove `[dist.github-custom-runners]` override that forced `aarch64-unknown-linux-gnu` onto `ubuntu-latest` (an x86_64 runner), breaking cross-compilation with `can't find crate for core`
- Without the override, cargo-dist uses its default container image with proper aarch64 cross-compilation tooling

## Test plan

- [ ] CI passes on this PR (the Release workflow dry-run should show a container in the aarch64-linux matrix entry)
- [ ] Next release builds aarch64-linux successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)