### PR TITLE
feat(dependency-freshness): add npm workspace support

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -500,6 +500,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1111,7 @@ dependencies = [
 name = "scute-core"
 version = "0.0.3"
 dependencies = [
+ "glob",
  "googletest",
  "ignore",
  "insta",

--- a/crates/scute-core/Cargo.toml
+++ b/crates/scute-core/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 workspace = true
 
 [dependencies]
+glob = "0.3"
 ignore = "0.4.25"
 libsais = { version = "0.2", default-features = false }
 minreq = { version = "2", features = ["https"] }

--- a/crates/scute-core/src/dependency_freshness/npm/mod.rs
+++ b/crates/scute-core/src/dependency_freshness/npm/mod.rs
@@ -22,10 +22,14 @@ pub(super) fn fetch_outdated(target: &Path) -> Result<Vec<OutdatedDependency>, F
         return Ok(vec![]);
     }
 
-    parse_outdated(&stdout, target)
+    let layout = WorkspaceLayout::from_target(target);
+    parse_outdated(&stdout, &layout)
 }
 
-fn parse_outdated(json: &str, target: &Path) -> Result<Vec<OutdatedDependency>, FetchError> {
+fn parse_outdated(
+    json: &str,
+    layout: &WorkspaceLayout,
+) -> Result<Vec<OutdatedDependency>, FetchError> {
     let root: serde_json::Value =
         serde_json::from_str(json).map_err(|e| FetchError::Failed(e.to_string()))?;
 
@@ -33,7 +37,6 @@ fn parse_outdated(json: &str, target: &Path) -> Result<Vec<OutdatedDependency>, 
         .as_object()
         .ok_or_else(|| FetchError::Failed("npm outdated returned non-object".into()))?;
 
-    let layout = WorkspaceLayout::from_target(target);
     let mut outdated = Vec::new();
 
     for (name, info) in packages {
@@ -46,7 +49,7 @@ fn parse_outdated(json: &str, target: &Path) -> Result<Vec<OutdatedDependency>, 
         };
 
         for entry in entries {
-            if let Some(dependency) = parse_entry(name, entry, &layout) {
+            if let Some(dependency) = parse_entry(name, entry, layout) {
                 outdated.push(dependency);
             }
         }
@@ -137,45 +140,51 @@ impl WorkspaceLayout {
 fn discover_members(target: &Path, patterns: &[serde_json::Value]) -> HashMap<String, String> {
     let mut members = HashMap::new();
 
-    for pattern in patterns.iter().filter_map(|v| v.as_str()) {
-        for dir in resolve_workspace_pattern(target, pattern) {
-            if !dir.join("package.json").exists() {
-                continue;
-            }
-            let Some(basename) = dir.file_name() else {
-                continue;
-            };
-            let Ok(relative) = dir.strip_prefix(target) else {
-                continue;
-            };
-            members.insert(
-                basename.to_string_lossy().into_owned(),
-                format!("{}/package.json", relative.display()),
-            );
-        }
+    let dirs = patterns
+        .iter()
+        .filter_map(|v| v.as_str())
+        .flat_map(|pattern| resolve_workspace_pattern(target, pattern));
+
+    for dir in dirs {
+        register_member(target, &dir, &mut members);
     }
 
     members
 }
 
 fn resolve_workspace_pattern(target: &Path, pattern: &str) -> Vec<std::path::PathBuf> {
-    if !pattern.contains('*') {
-        return vec![target.join(pattern)];
+    let full = format!("{}/{pattern}", target.display());
+    glob::glob(&full)
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .filter(|p| p.is_dir())
+        .collect()
+}
+
+fn register_member(target: &Path, dir: &Path, members: &mut HashMap<String, String>) {
+    if !dir.join("package.json").exists() {
+        return;
+    }
+    let Ok(relative) = dir.strip_prefix(target) else {
+        return;
+    };
+    let manifest = format!("{}/package.json", relative.display());
+
+    // Index by directory basename. npm currently uses directory names
+    // in the `dependent` field of `npm outdated --json`.
+    if let Some(basename) = dir.file_name() {
+        members.insert(basename.to_string_lossy().into_owned(), manifest.clone());
     }
 
-    // For glob patterns like "packages/*", list the parent directory.
-    let Some(prefix) = pattern.strip_suffix("/*") else {
-        return vec![];
-    };
+    // Also index by package name, in case npm changes behavior.
+    if let Some(pkg_name) = read_package_name(dir) {
+        members.insert(pkg_name, manifest);
+    }
+}
 
-    let parent = target.join(prefix);
-    let Ok(entries) = std::fs::read_dir(parent) else {
-        return vec![];
-    };
-
-    entries
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir())
-        .collect()
+fn read_package_name(dir: &Path) -> Option<String> {
+    let contents = std::fs::read_to_string(dir.join("package.json")).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&contents).ok()?;
+    value["name"].as_str().map(String::from)
 }

--- a/crates/scute-core/tests/dependency_freshness.rs
+++ b/crates/scute-core/tests/dependency_freshness.rs
@@ -124,7 +124,7 @@ fn workspace_member_location_points_to_subcrate_manifest() {
 #[test]
 fn npm_workspace_member_location_points_to_member_manifest() {
     let dir = TestProject::npm()
-        .member("app", |m| m.dependency("is-odd", "1.0.0"))
+        .member("apps/web", |m| m.dependency("is-odd", "1.0.0"))
         .build();
 
     let dependencies = fetch_outdated(dir.path()).unwrap();
@@ -133,15 +133,15 @@ fn npm_workspace_member_location_points_to_member_manifest() {
     assert_eq!(dependencies[0].name, "is-odd");
     assert_eq!(
         dependencies[0].location.as_deref(),
-        Some("packages/app/package.json")
+        Some("apps/web/package.json")
     );
 }
 
 #[test]
 fn npm_workspace_reports_outdated_from_multiple_members() {
     let dir = TestProject::npm()
-        .member("app", |m| m.dependency("is-odd", "1.0.0"))
-        .member("lib", |m| m.dependency("is-number", "1.0.0"))
+        .member("apps/web", |m| m.dependency("is-odd", "1.0.0"))
+        .member("packages/utils", |m| m.dependency("is-number", "1.0.0"))
         .build();
 
     let dependencies = fetch_outdated(dir.path()).unwrap();
@@ -158,7 +158,7 @@ fn npm_workspace_reports_outdated_from_multiple_members() {
 fn npm_workspace_root_deps_location_points_to_root_manifest() {
     let dir = TestProject::npm()
         .dependency("is-odd", "1.0.0")
-        .member("app", |m| m.dependency("is-even", "1.0.0"))
+        .member("apps/web", |m| m.dependency("is-even", "1.0.0"))
         .build();
 
     let dependencies = fetch_outdated(dir.path()).unwrap();
@@ -170,17 +170,45 @@ fn npm_workspace_root_deps_location_points_to_root_manifest() {
 #[test]
 fn npm_workspace_shared_dep_reported_per_member() {
     let dir = TestProject::npm()
-        .member("app", |m| m.dependency("is-odd", "1.0.0"))
-        .member("lib", |m| m.dependency("is-odd", "1.0.0"))
+        .member("apps/web", |m| m.dependency("is-odd", "1.0.0"))
+        .member("packages/utils", |m| m.dependency("is-odd", "1.0.0"))
         .build();
 
     let dependencies = fetch_outdated(dir.path()).unwrap();
 
-    let is_odd_deps: Vec<_> = dependencies.iter().filter(|d| d.name == "is-odd").collect();
+    let locations: Vec<_> = dependencies
+        .iter()
+        .filter(|d| d.name == "is-odd")
+        .filter_map(|d| d.location.as_deref())
+        .collect();
     assert_eq!(
-        is_odd_deps.len(),
+        locations.len(),
         2,
-        "shared dep should be reported per member, got: {is_odd_deps:?}"
+        "shared dep should be reported per member, got: {locations:?}"
+    );
+    assert!(
+        locations.contains(&"apps/web/package.json"),
+        "missing web, got: {locations:?}"
+    );
+    assert!(
+        locations.contains(&"packages/utils/package.json"),
+        "missing utils, got: {locations:?}"
+    );
+}
+
+#[test]
+fn npm_workspace_member_dev_dep_location_points_to_member_manifest() {
+    let dir = TestProject::npm()
+        .member("apps/web", |m| m.dev_dependency("is-odd", "1.0.0"))
+        .build();
+
+    let dependencies = fetch_outdated(dir.path()).unwrap();
+
+    assert_eq!(dependencies.len(), 1);
+    assert_eq!(dependencies[0].name, "is-odd");
+    assert_eq!(
+        dependencies[0].location.as_deref(),
+        Some("apps/web/package.json")
     );
 }
 

--- a/crates/scute-test-utils/src/project.rs
+++ b/crates/scute-test-utils/src/project.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use tempfile::TempDir;
 
 enum ProjectKind {
@@ -8,9 +10,10 @@ enum ProjectKind {
 
 /// A throwaway project directory for integration tests.
 ///
-/// Use [`cargo()`](Self::cargo) or [`empty()`](Self::empty) to start, chain
-/// builder methods, then call [`build()`](Self::build) to materialize the
-/// directory. The returned [`TempDir`] is cleaned up on drop.
+/// Use [`cargo()`](Self::cargo), [`npm()`](Self::npm), or
+/// [`empty()`](Self::empty) to start, chain builder methods, then call
+/// [`build()`](Self::build) to materialize the directory. The returned
+/// [`TempDir`] is cleaned up on drop.
 pub struct TestProject {
     kind: ProjectKind,
     dependencies: Vec<(String, String)>,
@@ -75,14 +78,14 @@ impl TestProject {
         self
     }
 
-    /// Add a workspace member. The closure receives an empty [`TestMember`]
-    /// to configure with its own dependencies.
-    pub fn member(mut self, name: &str, build: impl FnOnce(TestMember) -> TestMember) -> Self {
+    /// Add a workspace member at the given relative path. The closure receives
+    /// an empty [`TestMember`] to configure with its own dependencies.
+    pub fn member(mut self, path: &str, build: impl FnOnce(TestMember) -> TestMember) -> Self {
         let member = build(TestMember {
             dependencies: Vec::new(),
             dev_dependencies: Vec::new(),
         });
-        self.members.push((name.into(), member));
+        self.members.push((path.into(), member));
         self
     }
 
@@ -139,12 +142,12 @@ fn setup_cargo_project(
             "[package]\nname = \"test-project\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
         )
     } else {
-        let names: Vec<&str> = members.iter().map(|(n, _)| n.as_str()).collect();
+        let paths: Vec<&str> = members.iter().map(|(p, _)| p.as_str()).collect();
         format!(
             "[workspace]\nmembers = [{}]\n",
-            names
+            paths
                 .iter()
-                .map(|n| format!("\"{n}\""))
+                .map(|p| format!("\"{p}\""))
                 .collect::<Vec<_>>()
                 .join(", ")
         )
@@ -160,24 +163,20 @@ fn setup_cargo_project(
         std::fs::write(src.join("lib.rs"), "").unwrap();
     }
 
-    for (name, member) in members {
-        setup_cargo_member(dir, name, &member.dependencies, &member.dev_dependencies);
+    for (path, member) in members {
+        setup_cargo_member(dir, path, member);
     }
 }
 
-fn setup_cargo_member(
-    dir: &TempDir,
-    name: &str,
-    dependencies: &[(String, String)],
-    dev_dependencies: &[(String, String)],
-) {
-    let member_dir = dir.path().join(name);
+fn setup_cargo_member(dir: &TempDir, path: &str, member: &TestMember) {
+    let member_dir = dir.path().join(path);
     std::fs::create_dir_all(member_dir.join("src")).unwrap();
     std::fs::write(member_dir.join("src/lib.rs"), "").unwrap();
 
+    let name = Path::new(path).file_name().unwrap().to_string_lossy();
     let mut toml =
         format!("[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
-    append_cargo_deps(&mut toml, dependencies, dev_dependencies);
+    append_cargo_deps(&mut toml, &member.dependencies, &member.dev_dependencies);
     std::fs::write(member_dir.join("Cargo.toml"), toml).unwrap();
 }
 
@@ -194,7 +193,7 @@ fn setup_npm_project(
     if !members.is_empty() {
         let workspace_paths: Vec<serde_json::Value> = members
             .iter()
-            .map(|(name, _)| serde_json::Value::String(format!("packages/{name}")))
+            .map(|(path, _)| serde_json::Value::String(path.clone()))
             .collect();
         pkg.insert("workspaces".into(), workspace_paths.into());
     }
@@ -204,8 +203,8 @@ fn setup_npm_project(
     let json = serde_json::to_string_pretty(&pkg).unwrap();
     std::fs::write(dir.path().join("package.json"), json).unwrap();
 
-    for (name, member) in members {
-        setup_npm_member(dir, name, &member.dependencies, &member.dev_dependencies);
+    for (path, member) in members {
+        setup_npm_member(dir, path, member);
     }
 
     let output = std::process::Command::new("npm")
@@ -221,20 +220,17 @@ fn setup_npm_project(
     );
 }
 
-fn setup_npm_member(
-    dir: &TempDir,
-    name: &str,
-    dependencies: &[(String, String)],
-    dev_dependencies: &[(String, String)],
-) {
-    let member_dir = dir.path().join("packages").join(name);
+fn setup_npm_member(dir: &TempDir, path: &str, member: &TestMember) {
+    let member_dir = dir.path().join(path);
     std::fs::create_dir_all(&member_dir).unwrap();
 
+    let basename = Path::new(path).file_name().unwrap().to_string_lossy();
+
     let mut pkg = serde_json::Map::new();
-    pkg.insert("name".into(), format!("@test/{name}").into());
+    pkg.insert("name".into(), format!("@test/{basename}").into());
     pkg.insert("version".into(), "1.0.0".into());
 
-    append_npm_deps(&mut pkg, dependencies, dev_dependencies);
+    append_npm_deps(&mut pkg, &member.dependencies, &member.dev_dependencies);
 
     let json = serde_json::to_string_pretty(&pkg).unwrap();
     std::fs::write(member_dir.join("package.json"), json).unwrap();


### PR DESCRIPTION
## Summary

- Handle npm workspace output format where shared dependencies return an array instead of an object per package
- `WorkspaceLayout` reads the `workspaces` field from root `package.json`, resolves member directories, and maps each `dependent` name to its relative manifest path
- Extend `TestProject` npm builder with workspace member support (mirroring the existing Cargo workspace builder)

Part of #24 (Slice 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)