### PR TITLE
refactor(dependency-freshness): replace PackageManager enum with trait

### DIFF
--- a/crates/scute-core/src/dependency_freshness/cargo/mod.rs
+++ b/crates/scute-core/src/dependency_freshness/cargo/mod.rs
@@ -3,69 +3,73 @@ mod metadata;
 
 use std::path::Path;
 
-use super::{FetchError, OutdatedDependency};
+use super::{FetchError, OutdatedDependency, PackageManager};
 
-/// Ask `cargo metadata` whether this directory is the workspace root.
-/// Returns true for both standalone projects and workspace roots,
-/// false for workspace members (whose root is an ancestor).
-pub(super) fn is_project_root(target: &Path) -> bool {
-    let Ok(output) = std::process::Command::new("cargo")
-        .args(["metadata", "--no-deps", "--format-version", "1"])
-        .current_dir(target)
-        .output()
-    else {
-        return false;
-    };
+pub(super) struct Cargo;
 
-    if !output.status.success() {
-        return false;
-    }
+impl PackageManager for Cargo {
+    /// Ask `cargo metadata` whether this directory is the workspace root.
+    /// Returns true for both standalone projects and workspace roots,
+    /// false for workspace members (whose root is an ancestor).
+    fn is_project_root(&self, target: &Path) -> bool {
+        let Ok(output) = std::process::Command::new("cargo")
+            .args(["metadata", "--no-deps", "--format-version", "1"])
+            .current_dir(target)
+            .output()
+        else {
+            return false;
+        };
 
-    let workspace_root = String::from_utf8(output.stdout)
-        .ok()
-        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
-        .and_then(|v| v["workspace_root"].as_str().map(String::from));
-
-    let Some(canonical_target) = target.canonicalize().ok() else {
-        return false;
-    };
-
-    workspace_root
-        .as_deref()
-        .is_some_and(|root| Path::new(root) == canonical_target)
-}
-
-pub(super) fn fetch_outdated(target: &Path) -> Result<Vec<OutdatedDependency>, FetchError> {
-    let direct_deps = metadata::collect_direct_deps(target)?;
-
-    let latest_versions = fetch_latest_versions(&direct_deps);
-
-    let mut outdated = Vec::new();
-    let mut errors = Vec::new();
-
-    for (dependency, result) in &latest_versions {
-        match result {
-            Ok(Some(latest)) if latest > &dependency.version => {
-                outdated.push(OutdatedDependency {
-                    name: dependency.name.clone(),
-                    current: dependency.version.clone(),
-                    latest: latest.clone(),
-                    location: dependency.location_relative_to(target),
-                });
-            }
-            Ok(_) => {}
-            Err(error) => errors.push(format!("{}: {error}", dependency.name)),
+        if !output.status.success() {
+            return false;
         }
+
+        let workspace_root = String::from_utf8(output.stdout)
+            .ok()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .and_then(|v| v["workspace_root"].as_str().map(String::from));
+
+        let Some(canonical_target) = target.canonicalize().ok() else {
+            return false;
+        };
+
+        workspace_root
+            .as_deref()
+            .is_some_and(|root| Path::new(root) == canonical_target)
     }
 
-    if outdated.is_empty() && errors.len() == direct_deps.len() && !direct_deps.is_empty() {
-        return Err(FetchError::Failed(format!(
-            "all registry lookups failed: {}",
-            errors.join(", ")
-        )));
-    }
+    fn fetch_outdated(&self, target: &Path) -> Result<Vec<OutdatedDependency>, FetchError> {
+        let direct_deps = metadata::collect_direct_deps(target)?;
 
-    Ok(outdated)
+        let latest_versions = fetch_latest_versions(&direct_deps);
+
+        let mut outdated = Vec::new();
+        let mut errors = Vec::new();
+
+        for (dependency, result) in &latest_versions {
+            match result {
+                Ok(Some(latest)) if latest > &dependency.version => {
+                    outdated.push(OutdatedDependency {
+                        name: dependency.name.clone(),
+                        current: dependency.version.clone(),
+                        latest: latest.clone(),
+                        location: dependency.location_relative_to(target),
+                    });
+                }
+                Ok(_) => {}
+                Err(error) => errors.push(format!("{}: {error}", dependency.name)),
+            }
+        }
+
+        if outdated.is_empty() && errors.len() == direct_deps.len() && !direct_deps.is_empty() {
+            return Err(FetchError::Failed(format!(
+                "all registry lookups failed: {}",
+                errors.join(", ")
+            )));
+        }
+
+        Ok(outdated)
+    }
 }
 
 fn fetch_latest_versions(
@@ -89,7 +93,17 @@ fn fetch_latest_versions(
 
         handles
             .into_iter()
-            .filter_map(|handle| handle.join().ok())
+            .zip(dependencies)
+            .map(|(handle, dep)| match handle.join() {
+                Ok(result) => result,
+                Err(_) => (
+                    dep,
+                    Err(FetchError::Failed(format!(
+                        "registry lookup failed for {}",
+                        dep.name
+                    ))),
+                ),
+            })
             .collect()
     })
 }

--- a/crates/scute-core/src/dependency_freshness/mod.rs
+++ b/crates/scute-core/src/dependency_freshness/mod.rs
@@ -144,6 +144,81 @@ fn classify_error(err: FetchError) -> ExecutionError {
     }
 }
 
+/// A package manager that can detect project roots and fetch outdated
+/// dependencies.
+trait PackageManager: Send + Sync {
+    /// Returns true for standalone projects and workspace roots, false for
+    /// workspace members whose root is an ancestor.
+    fn is_project_root(&self, dir: &Path) -> bool;
+
+    /// Returns dependencies with locations relative to `dir`.
+    fn fetch_outdated(&self, dir: &Path) -> Result<Vec<OutdatedDependency>, FetchError>;
+}
+
+/// A discovered manifest file paired with its package manager.
+struct Manifest {
+    dir: std::path::PathBuf,
+    pm: Box<dyn PackageManager>,
+}
+
+impl Manifest {
+    fn detect(path: &Path) -> Option<Self> {
+        let dir = path.parent()?.to_path_buf();
+        let pm: Box<dyn PackageManager> = match path.file_name()?.to_str()? {
+            "Cargo.toml" => Box::new(cargo::Cargo),
+            "package.json" => Box::new(npm::Npm),
+            _ => return None,
+        };
+        Some(Self { dir, pm })
+    }
+
+    fn is_project_root(&self) -> bool {
+        self.pm.is_project_root(&self.dir)
+    }
+
+    fn fetch_outdated(&self) -> Result<Vec<OutdatedDependency>, FetchError> {
+        self.pm.fetch_outdated(&self.dir)
+    }
+}
+
+fn collect_projects(target: &Path) -> Result<Vec<Manifest>, FetchError> {
+    let walker = ignore::WalkBuilder::new(target)
+        .standard_filters(true)
+        .build();
+
+    let manifests: Vec<_> = walker
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
+        .filter_map(|entry| Manifest::detect(entry.path()))
+        .collect();
+
+    let dirs: Vec<_> = manifests
+        .iter()
+        .map(|m| m.dir.display().to_string())
+        .collect();
+
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = manifests
+            .into_iter()
+            .map(|manifest| scope.spawn(move || manifest.is_project_root().then_some(manifest)))
+            .collect();
+
+        let mut projects = Vec::new();
+        for (handle, dir) in handles.into_iter().zip(&dirs) {
+            match handle.join() {
+                Ok(Some(manifest)) => projects.push(manifest),
+                Ok(None) => {}
+                Err(_) => {
+                    return Err(FetchError::Failed(format!(
+                        "root detection failed for {dir}"
+                    )));
+                }
+            }
+        }
+        Ok(projects)
+    })
+}
+
 /// Walk `target` for supported package managers, identify project roots,
 /// and collect outdated dependencies from each one.
 ///
@@ -153,9 +228,9 @@ fn classify_error(err: FetchError) -> ExecutionError {
 /// Fails fast: if any project root errors out, the whole call fails.
 #[doc(hidden)]
 pub fn fetch_outdated(target: &Path) -> Result<Vec<OutdatedDependency>, FetchError> {
-    let roots = discover_project_roots(target);
+    let projects = collect_projects(target)?;
 
-    if roots.is_empty() {
+    if projects.is_empty() {
         return Err(FetchError::InvalidTarget(
             "no supported project found".into(),
         ));
@@ -163,13 +238,9 @@ pub fn fetch_outdated(target: &Path) -> Result<Vec<OutdatedDependency>, FetchErr
 
     let mut all_outdated = Vec::new();
 
-    for (project_dir, package_manager) in &roots {
-        let mut deps = match package_manager {
-            PackageManager::Cargo => cargo::fetch_outdated(project_dir)?,
-            PackageManager::Npm => npm::fetch_outdated(project_dir)?,
-        };
-
-        let prefix = project_dir.strip_prefix(target).unwrap_or(project_dir);
+    for project in &projects {
+        let mut deps = project.fetch_outdated()?;
+        let prefix = project.dir.strip_prefix(target).unwrap_or(&project.dir);
 
         if !prefix.as_os_str().is_empty() {
             for dep in &mut deps {
@@ -184,60 +255,6 @@ pub fn fetch_outdated(target: &Path) -> Result<Vec<OutdatedDependency>, FetchErr
     }
 
     Ok(all_outdated)
-}
-
-#[derive(Debug, PartialEq)]
-enum PackageManager {
-    Cargo,
-    Npm,
-}
-
-impl std::fmt::Display for PackageManager {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Cargo => f.write_str("Cargo"),
-            Self::Npm => f.write_str("npm"),
-        }
-    }
-}
-
-fn discover_project_roots(target: &Path) -> Vec<(std::path::PathBuf, PackageManager)> {
-    let walker = ignore::WalkBuilder::new(target)
-        .standard_filters(true)
-        .build();
-
-    let manifests: Vec<_> = walker
-        .filter_map(Result::ok)
-        .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
-        .filter_map(|entry| {
-            let dir = entry.path().parent()?.to_path_buf();
-            match entry.file_name().to_str()? {
-                "Cargo.toml" => Some((dir, PackageManager::Cargo)),
-                "package.json" => Some((dir, PackageManager::Npm)),
-                _ => None,
-            }
-        })
-        .collect();
-
-    std::thread::scope(|scope| {
-        let handles: Vec<_> = manifests
-            .into_iter()
-            .map(|(dir, pm)| {
-                scope.spawn(move || {
-                    let is_root = match &pm {
-                        PackageManager::Cargo => cargo::is_project_root(&dir),
-                        PackageManager::Npm => npm::is_project_root(&dir),
-                    };
-                    is_root.then_some((dir, pm))
-                })
-            })
-            .collect();
-
-        handles
-            .into_iter()
-            .filter_map(|h| h.join().ok().flatten())
-            .collect()
-    })
 }
 
 fn evaluate(

--- a/crates/scute-core/src/dependency_freshness/npm/mod.rs
+++ b/crates/scute-core/src/dependency_freshness/npm/mod.rs
@@ -1,61 +1,66 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use super::{FetchError, OutdatedDependency};
+use super::{FetchError, OutdatedDependency, PackageManager};
 
-/// Ask `npm query :root` whether this directory is the project root.
-/// Returns true for both standalone projects and workspace roots,
-/// false for workspace members (whose root is an ancestor).
-pub(super) fn is_project_root(target: &Path) -> bool {
-    let Ok(output) = std::process::Command::new("npm")
-        .args(["query", ":root"])
-        .current_dir(target)
-        .output()
-    else {
-        return false;
-    };
+pub(super) struct Npm;
 
-    if !output.status.success() {
-        return false;
+impl PackageManager for Npm {
+    /// Ask `npm query :root` whether this directory is the project root.
+    /// Returns true for both standalone projects and workspace roots,
+    /// false for workspace members (whose root is an ancestor).
+    fn is_project_root(&self, target: &Path) -> bool {
+        let Ok(output) = std::process::Command::new("npm")
+            .args(["query", ":root"])
+            .current_dir(target)
+            .output()
+        else {
+            return false;
+        };
+
+        if !output.status.success() {
+            return false;
+        }
+
+        let root_path = String::from_utf8(output.stdout)
+            .ok()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+            .and_then(|v| {
+                v.as_array()?
+                    .first()?
+                    .get("path")?
+                    .as_str()
+                    .map(String::from)
+            });
+
+        let Some(canonical_target) = target.canonicalize().ok() else {
+            return false;
+        };
+
+        root_path
+            .as_deref()
+            .is_some_and(|root| Path::new(root) == canonical_target)
     }
 
-    let root_path = String::from_utf8(output.stdout)
-        .ok()
-        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
-        .and_then(|v| {
-            v.as_array()?
-                .first()?
-                .get("path")?
-                .as_str()
-                .map(String::from)
-        });
+    fn fetch_outdated(&self, target: &Path) -> Result<Vec<OutdatedDependency>, FetchError> {
+        let output = std::process::Command::new("npm")
+            .args(["outdated", "--json"])
+            .current_dir(target)
+            .output()
+            .map_err(|e| FetchError::Failed(format!("could not run npm outdated: {e}")))?;
 
-    let Some(canonical_target) = target.canonicalize().ok() else {
-        return false;
-    };
+        // npm outdated exits with code 1 when there ARE outdated deps.
+        // It only fails with non-json output on actual errors.
+        let stdout =
+            String::from_utf8(output.stdout).map_err(|e| FetchError::Failed(e.to_string()))?;
 
-    root_path
-        .as_deref()
-        .is_some_and(|root| Path::new(root) == canonical_target)
-}
+        if stdout.trim().is_empty() {
+            return Ok(vec![]);
+        }
 
-pub(super) fn fetch_outdated(target: &Path) -> Result<Vec<OutdatedDependency>, FetchError> {
-    let output = std::process::Command::new("npm")
-        .args(["outdated", "--json"])
-        .current_dir(target)
-        .output()
-        .map_err(|e| FetchError::Failed(format!("could not run npm outdated: {e}")))?;
-
-    // npm outdated exits with code 1 when there ARE outdated deps.
-    // It only fails with non-json output on actual errors.
-    let stdout = String::from_utf8(output.stdout).map_err(|e| FetchError::Failed(e.to_string()))?;
-
-    if stdout.trim().is_empty() {
-        return Ok(vec![]);
+        let layout = WorkspaceLayout::from_target(target);
+        parse_outdated(&stdout, &layout)
     }
-
-    let layout = WorkspaceLayout::from_target(target);
-    parse_outdated(&stdout, &layout)
 }
 
 fn parse_outdated(

--- a/handbook/pain-points.md
+++ b/handbook/pain-points.md
@@ -146,6 +146,10 @@ value.
   change signatures or restructure code before writing a failing test that
   requires the change. The test should drive the design, not the other way
   around.
+- **Dismissing review findings as "pre-existing".** (×1) Labeling issues as
+  "pre-existing" or "out of scope" to avoid fixing or even considering them.
+  Every finding deserves honest evaluation on its own merits, not a label
+  that shuts down the conversation.
 - **Dismissing tool feedback without verifying.** (×1) Tool reports a warning,
   agent rationalizes why it's acceptable without actually trying to fix it.
   The rationalization sounds reasonable but turns out to be wrong when


### PR DESCRIPTION
## Summary

- Replace `PackageManager` enum + match dispatch with a `PackageManager` trait. Each package manager (Cargo, Npm) is a struct implementing the trait behind `Box<dyn PackageManager>`.
- `Manifest::detect` is the single factory/registry point mapping filenames to implementations.
- Properly propagate thread panics in `collect_projects` and `fetch_latest_versions` instead of silently dropping them. Error messages include which directory or dependency failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)