### PR TITLE
feat(dependency-freshness): add pnpm support

### DIFF
--- a/crates/scute-core/src/dependency_freshness/mod.rs
+++ b/crates/scute-core/src/dependency_freshness/mod.rs
@@ -98,7 +98,7 @@ impl OutdatedDependency {
 
 /// Run the dependency-freshness check against a project directory.
 ///
-/// Discovers supported package managers (Cargo, npm) and checks each one found.
+/// Discovers supported package managers (Cargo, npm, pnpm) and checks each one found.
 ///
 /// # Errors
 ///

--- a/crates/scute-core/src/dependency_freshness/pnpm/mod.rs
+++ b/crates/scute-core/src/dependency_freshness/pnpm/mod.rs
@@ -10,6 +10,8 @@ impl PackageManager for Pnpm {
     }
 
     fn fetch_outdated(&self, target: &Path) -> Result<Vec<OutdatedDependency>, FetchError> {
+        // pnpm outdated exits with code 1 when there ARE outdated deps.
+        // We ignore the exit code and parse stdout directly.
         let output = std::process::Command::new("pnpm")
             .args(["outdated", "--format", "json"])
             .current_dir(target)
@@ -48,6 +50,7 @@ fn parse_outdated(json: &str) -> Result<Vec<OutdatedDependency>, FetchError> {
 fn parse_entry(name: &str, entry: &serde_json::Value) -> Option<OutdatedDependency> {
     let current = entry["current"]
         .as_str()
+        .or_else(|| entry["wanted"].as_str())
         .and_then(|v| v.parse::<semver::Version>().ok())?;
     let latest = entry["latest"]
         .as_str()

--- a/crates/scute-core/tests/dependency_freshness.rs
+++ b/crates/scute-core/tests/dependency_freshness.rs
@@ -8,18 +8,13 @@ mod package_managers;
 use scute_core::dependency_freshness::{self, OutdatedDependency, fetch_outdated};
 use scute_test_utils::TestProject;
 
-fn assert_single_dependency(
-    dependencies: &[OutdatedDependency],
-    name: &str,
-    expected_location: &str,
-) {
-    let matching: Vec<_> = dependencies.iter().filter(|d| d.name == name).collect();
-    assert_eq!(
-        matching.len(),
-        1,
-        "{name} should appear exactly once, got: {matching:?}"
+fn assert_dependency_at(dependencies: &[OutdatedDependency], name: &str, location: &str) {
+    assert!(
+        dependencies
+            .iter()
+            .any(|d| d.name == name && d.location.as_deref() == Some(location)),
+        "{name} at {location} not found in {dependencies:?}"
     );
-    assert_eq!(matching[0].location.as_deref(), Some(expected_location));
 }
 
 #[test]
@@ -58,12 +53,15 @@ fn polyglot_monorepo_reports_each_root_once_with_relative_locations() {
             "frontend",
             TestProject::npm().member("apps/web", |member| member.dependency("is-odd", "1.0.0")),
         )
+        .nested("tools", TestProject::pnpm().dependency("is-odd", "1.0.0"))
         .build();
 
     let dependencies = fetch_outdated(dir.path()).unwrap();
 
-    assert_single_dependency(&dependencies, "rand", "backend/crates/api/Cargo.toml");
-    assert_single_dependency(&dependencies, "is-odd", "frontend/apps/web/package.json");
+    assert_eq!(dependencies.len(), 3);
+    assert_dependency_at(&dependencies, "rand", "backend/crates/api/Cargo.toml");
+    assert_dependency_at(&dependencies, "is-odd", "frontend/apps/web/package.json");
+    assert_dependency_at(&dependencies, "is-odd", "tools/package.json");
 }
 
 #[test]

--- a/crates/scute-core/tests/dependency_freshness/package_managers.rs
+++ b/crates/scute-core/tests/dependency_freshness/package_managers.rs
@@ -60,7 +60,7 @@ fn excludes_transitive_dependencies(context: &Context) {
 #[test_case(&CARGO ; "cargo")]
 #[test_case(&NPM ; "npm")]
 #[test_case(&PNPM ; "pnpm")]
-fn reports_current_version(context: &Context) {
+fn reports_current_version_of_outdated_dependency(context: &Context) {
     let dir = (context.project)()
         .dependency(context.outdated_package, context.pinned_version)
         .build();
@@ -78,7 +78,7 @@ fn reports_current_version(context: &Context) {
 #[test_case(&CARGO ; "cargo")]
 #[test_case(&NPM ; "npm")]
 #[test_case(&PNPM ; "pnpm")]
-fn reports_latest_available_version(context: &Context) {
+fn reports_latest_version_of_outdated_dependency(context: &Context) {
     let dir = (context.project)()
         .dependency(context.outdated_package, context.pinned_version)
         .build();

--- a/crates/scute-test-utils/src/project.rs
+++ b/crates/scute-test-utils/src/project.rs
@@ -261,16 +261,16 @@ fn setup_js_project(
                 .unwrap();
             }
         }
-
-        for (path, member) in members {
-            setup_js_member(root, path, member);
-        }
     }
 
     append_js_deps(&mut pkg, dependencies, dev_dependencies);
 
     let json = serde_json::to_string_pretty(&pkg).unwrap();
     std::fs::write(root.join("package.json"), json).unwrap();
+
+    for (path, member) in members {
+        setup_js_member(root, path, member);
+    }
 
     let cmd = toolchain.command();
     let output = std::process::Command::new(cmd)


### PR DESCRIPTION
## Summary

- Add pnpm as a supported package manager for the dependency-freshness check
- Detect pnpm projects by `pnpm-lock.yaml` presence next to `package.json`
- Use `pnpm outdated --format json` to collect outdated deps
- Pass all parameterized contract tests shared with Cargo and npm

This is slice 1 (standalone projects). Workspace support and polyglot monorepo discovery coming in follow-up commits.

Part of #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)