### PR TITLE
docs: add scute.sh install scripts to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,21 @@ result. Agents and CI consume it the same way.
 Install:
 
 ```sh
-# Homebrew (macOS / Linux)
-brew install scute-sh/tap/scute
+# macOS / Linux
+curl -fsSL scute.sh/install | sh
+```
 
-# Cargo
-cargo install scute
+```powershell
+# Windows
+irm scute.sh/install.ps1 | iex
+```
 
-# Pre-built binary (if you have cargo-binstall)
-cargo binstall scute
+Or via [Homebrew](https://brew.sh) / [Cargo](https://doc.rust-lang.org/cargo/):
+
+```sh
+brew install scute-sh/tap/scute    # macOS / Linux
+cargo install scute                # from source
+cargo binstall scute               # pre-built binary
 ```
 
 Run a check:


### PR DESCRIPTION
## Summary

- Lead the Quickstart section with `curl | sh` (macOS/Linux) and `irm | iex` (Windows) one-liners using the new scute.sh hosted install scripts
- Keep Homebrew and Cargo as alternative install methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)