### PR TITLE
refactor(code-complexity): harden with shared validation and edge cases

### DIFF
--- a/crates/scute-cli/tests/acceptance.rs
+++ b/crates/scute-cli/tests/acceptance.rs
@@ -355,6 +355,14 @@ checks:
 
     #[test_case(Cli)]
     #[test_case(Mcp)]
+    fn nonexistent_source_dir_produces_error(interface: Interface) {
+        Scute::new(interface)
+            .check(&["code-complexity", "--source-dir", "/nonexistent/path"])
+            .expect_error("invalid_target");
+    }
+
+    #[test_case(Cli)]
+    #[test_case(Mcp)]
     fn focus_file_limits_to_matching_files(interface: Interface) {
         Scute::new(interface)
             .source_file("src/complex.rs", COMPLEX_SOURCE)

--- a/crates/scute-core/src/code_complexity/check.rs
+++ b/crates/scute-core/src/code_complexity/check.rs
@@ -38,10 +38,11 @@ pub fn check(
     let exclude = definition.exclude.as_deref().unwrap_or_default();
     let rust_files = discover_rust_files(&canonical_dir, exclude);
 
-    let focus: Vec<PathBuf> = focus_files
-        .iter()
-        .filter_map(|p| p.canonicalize().ok())
-        .collect();
+    let focus =
+        match files::validate_focus_files(focus_files, &["rs"], "only Rust files are supported") {
+            Ok(files) => files,
+            Err(errors) => return Ok(errors),
+        };
 
     let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
     let mut evaluations = Vec::new();
@@ -323,5 +324,32 @@ mod tests {
 
         assert_eq!(evals.len(), 1);
         assert!(evals[0].is_pass()); // fallback pass, no rust files
+    }
+
+    #[test]
+    fn nonexistent_focus_file_produces_error() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let evals = check(
+            dir.path(),
+            &[PathBuf::from("/nonexistent/file.rs")],
+            &Definition::default(),
+        )
+        .unwrap();
+
+        assert_eq!(evals.len(), 1);
+        assert!(evals[0].is_error());
+    }
+
+    #[test]
+    fn unsupported_focus_file_extension_produces_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let py_file = dir.path().join("code.py");
+        fs::write(&py_file, "def foo(): pass").unwrap();
+
+        let evals = check(dir.path(), &[py_file], &Definition::default()).unwrap();
+
+        assert_eq!(evals.len(), 1);
+        assert!(evals[0].is_error());
     }
 }

--- a/crates/scute-core/src/code_complexity/score.rs
+++ b/crates/scute-core/src/code_complexity/score.rs
@@ -129,17 +129,11 @@ fn collect_functions(node: tree_sitter::Node, src: &[u8], results: &mut Vec<Func
 }
 
 fn enclosing_impl_type(node: tree_sitter::Node, src: &[u8]) -> Option<String> {
-    let mut current = node;
-    while let Some(parent) = current.parent() {
-        if parent.kind() == "impl_item" {
-            return parent
-                .child_by_field_name("type")
-                .and_then(|t| t.utf8_text(src).ok())
-                .map(String::from);
-        }
-        current = parent;
-    }
-    None
+    std::iter::successors(node.parent(), tree_sitter::Node::parent)
+        .find(|n| n.kind() == "impl_item")
+        .and_then(|n| n.child_by_field_name("type"))
+        .and_then(|t| t.utf8_text(src).ok())
+        .map(String::from)
 }
 
 fn complexity(
@@ -224,20 +218,17 @@ fn score_node(
 }
 
 fn nesting_chain(node: tree_sitter::Node) -> Vec<Construct> {
-    let mut chain = vec![];
-    let mut current = node;
-    while let Some(parent) = current.parent() {
-        if parent.kind() == "function_item" {
-            break;
+    let ancestors = std::iter::successors(node.parent(), tree_sitter::Node::parent);
+    let mut chain = Vec::new();
+    for parent in ancestors {
+        match parent.kind() {
+            "function_item" => break,
+            "closure_expression" => {
+                chain.push(Construct::Closure);
+                break;
+            }
+            kind => chain.extend(parse_construct(kind)),
         }
-        if parent.kind() == "closure_expression" {
-            chain.push(Construct::Closure);
-            break;
-        }
-        if let Some(construct) = parse_construct(parent.kind()) {
-            chain.push(construct);
-        }
-        current = parent;
     }
     chain.reverse();
     chain
@@ -659,6 +650,19 @@ mod tests {
                 increment: 3,
             })
         );
+    }
+
+    #[test]
+    fn empty_source_returns_no_functions() {
+        let results = score_functions("", &tree_sitter_rust::LANGUAGE.into());
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn broken_syntax_does_not_panic() {
+        let results = score_functions("fn f(x: i32 -> { x + }", &tree_sitter_rust::LANGUAGE.into());
+        // tree-sitter recovers from errors — should not panic
+        let _ = results;
     }
 
     // outer: inner fn bumps nesting to 1, if inside inner at nesting 1 = +2, if in outer = +1 → 3

--- a/crates/scute-core/src/code_similarity/check.rs
+++ b/crates/scute-core/src/code_similarity/check.rs
@@ -92,7 +92,11 @@ pub fn check(
     });
 
     let canonical_dir = files::validate_source_dir(source_dir)?;
-    let focus_files = match validate_focus_files(focus_files) {
+    let focus_files = match files::validate_focus_files(
+        focus_files,
+        &["rs", "js", "jsx", "mjs", "cjs", "ts", "tsx"],
+        "only Rust, JavaScript, and TypeScript files are supported",
+    ) {
         Ok(files) => files,
         Err(errors) => return Ok(errors),
     };
@@ -157,45 +161,6 @@ fn read_sources(
             Some((path.display().to_string(), content, lang))
         })
         .collect()
-}
-
-fn validate_focus_files(files: &[PathBuf]) -> Result<Vec<PathBuf>, Vec<Evaluation>> {
-    let mut canonical = Vec::new();
-    let mut errors = Vec::new();
-    for path in files {
-        match validate_focus_file(path) {
-            Ok(p) => canonical.push(p),
-            Err(e) => errors.push(e),
-        }
-    }
-    if errors.is_empty() {
-        Ok(canonical)
-    } else {
-        Err(errors)
-    }
-}
-
-fn validate_focus_file(path: &Path) -> Result<PathBuf, Evaluation> {
-    if language_for_path(path).is_none() {
-        return Err(Evaluation::errored(
-            path.display().to_string(),
-            ExecutionError {
-                code: "unsupported_language".into(),
-                message: format!("unsupported file type: {}", path.display()),
-                recovery: "only Rust, JavaScript, and TypeScript files are supported".into(),
-            },
-        ));
-    }
-    path.canonicalize().map_err(|_| {
-        Evaluation::errored(
-            path.display().to_string(),
-            ExecutionError {
-                code: "unreadable_file".into(),
-                message: format!("cannot read file: {}", path.display()),
-                recovery: "check that the file exists and is readable".into(),
-            },
-        )
-    })
 }
 
 fn detect_clones(
@@ -656,28 +621,6 @@ mod tests {
         let evidence = unwrap_evidence(&evals[0]);
         assert_location_contains(evidence, "a.rs");
         assert_location_contains(evidence, "b.rs");
-    }
-
-    #[test]
-    fn unsupported_focus_file_produces_errored_evaluation() {
-        let dir = make_dir(&[("script.py", "def foo(): pass")]);
-
-        let evals = check_focused(dir.path(), &[dir.path().join("script.py")]);
-
-        assert_that!(evals, len(eq(1)));
-        assert!(evals[0].is_error());
-        assert_that!(evals[0].target, contains_substring("script.py"));
-    }
-
-    #[test]
-    fn unreadable_focus_file_produces_errored_evaluation() {
-        let dir = TempDir::new().unwrap();
-
-        let evals = check_focused(dir.path(), &[dir.path().join("missing.rs")]);
-
-        assert_that!(evals, len(eq(1)));
-        assert!(evals[0].is_error());
-        assert_that!(evals[0].target, contains_substring("missing.rs"));
     }
 
     #[test]

--- a/crates/scute-core/src/files.rs
+++ b/crates/scute-core/src/files.rs
@@ -26,6 +26,66 @@ pub fn walk_source_files(
         .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))
 }
 
+/// Validate and canonicalize focus files.
+///
+/// Checks that each file has a supported extension and exists on disk.
+/// Returns canonical paths on success, or errored evaluations on failure.
+///
+/// # Errors
+///
+/// Returns errored [`Evaluation`](crate::Evaluation)s when any file has an
+/// unsupported extension or cannot be read.
+pub fn validate_focus_files(
+    files: &[PathBuf],
+    supported_extensions: &[&str],
+    supported_msg: &str,
+) -> Result<Vec<PathBuf>, Vec<crate::Evaluation>> {
+    let mut canonical = Vec::new();
+    let mut errors = Vec::new();
+    for path in files {
+        match validate_focus_file(path, supported_extensions, supported_msg) {
+            Ok(p) => canonical.push(p),
+            Err(e) => errors.push(e),
+        }
+    }
+    if errors.is_empty() {
+        Ok(canonical)
+    } else {
+        Err(errors)
+    }
+}
+
+fn validate_focus_file(
+    path: &Path,
+    supported_extensions: &[&str],
+    supported_msg: &str,
+) -> Result<PathBuf, crate::Evaluation> {
+    let has_supported_ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|ext| supported_extensions.contains(&ext));
+    if !has_supported_ext {
+        return Err(crate::Evaluation::errored(
+            path.display().to_string(),
+            crate::ExecutionError {
+                code: "unsupported_language".into(),
+                message: format!("unsupported file type: {}", path.display()),
+                recovery: supported_msg.into(),
+            },
+        ));
+    }
+    path.canonicalize().map_err(|_| {
+        crate::Evaluation::errored(
+            path.display().to_string(),
+            crate::ExecutionError {
+                code: "unreadable_file".into(),
+                message: format!("cannot read file: {}", path.display()),
+                recovery: "check that the file exists and is readable".into(),
+            },
+        )
+    })
+}
+
 /// # Errors
 ///
 /// Returns `ExecutionError` if the path cannot be canonicalized.
@@ -76,6 +136,56 @@ mod tests {
         fs::write(dir.path().join("sub/b.rs"), "").unwrap();
 
         assert_eq!(walk(dir.path(), &[]).len(), 2);
+    }
+
+    #[test]
+    fn focus_files_rejects_unsupported_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let py_file = dir.path().join("script.py");
+        fs::write(&py_file, "").unwrap();
+
+        let result = validate_focus_files(&[py_file], &["rs"], "only Rust files are supported");
+
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].is_error());
+        assert!(errors[0].target.contains("script.py"));
+    }
+
+    #[test]
+    fn focus_files_rejects_nonexistent_file() {
+        let missing = PathBuf::from("/does/not/exist.rs");
+
+        let result = validate_focus_files(&[missing], &["rs"], "only Rust files are supported");
+
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].is_error());
+    }
+
+    #[test]
+    fn focus_files_canonicalizes_valid_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("real.rs");
+        fs::write(&file, "").unwrap();
+
+        let result = validate_focus_files(
+            std::slice::from_ref(&file),
+            &["rs"],
+            "only Rust files are supported",
+        );
+
+        let paths = result.unwrap();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], file.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn focus_files_returns_empty_for_no_files() {
+        let result: Result<Vec<PathBuf>, _> =
+            validate_focus_files(&[], &["rs"], "only Rust files are supported");
+
+        assert!(result.unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Extracted `validate_focus_files` from code-similarity into shared `files.rs`, so both checks use the same validation
- Replaced manual `while let` parent traversal loops with `std::iter::successors` in `nesting_chain` and `enclosing_impl_type`
- Added edge case tests: empty source, broken syntax, nonexistent focus files, unsupported extensions, nonexistent source dir

Part of #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)