### PR TITLE
docs(code-complexity): public documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ result. Agents and CI consume it the same way.
 
 | Check                                                         | What it catches                 | Scope                        |
 | ------------------------------------------------------------- | ------------------------------- | ---------------------------- |
-| [`commit-message`](docs/checks/commit-message.md)             | Conventional Commits violations | Any project                  |
+| [`code-complexity`](docs/checks/code-complexity.md)            | Cognitive complexity per function | Rust                         |
 | [`code-similarity`](docs/checks/code-similarity.md)           | Structural code duplication     | Rust, JavaScript, TypeScript |
+| [`commit-message`](docs/checks/commit-message.md)             | Conventional Commits violations | Any project                  |
 | [`dependency-freshness`](docs/checks/dependency-freshness.md) | Outdated dependencies           | Cargo, npm, pnpm             |
 
 ## Quickstart
@@ -261,18 +262,14 @@ rules, etc.) telling the agent to use Scute checks proactively. Here's what
 Scute's own config looks like:
 
 ```markdown
-## MCP Tools Are Part of the Workflow
+# MCP Tools Are Part of the Workflow
 
-Before any action, think about which MCP tools are relevant to what you're
-about to do.
+Scute's MCP server has check tools. Use them proactively:
 
-Scute's MCP server has check tools to help you work more efficiently:
-
-- `check_commit_message`
-- `check_dependency_freshness`
-- `check_code_similarity`
-
-Use them.
+- `check_commit_message` — before making a commit
+- `check_code_complexity` — after changing a function or implementing a new one
+- `check_code_similarity` — after changing a function or implementing a new one
+- `check_dependency_freshness` — after adding or updating a dependency
 ```
 
 ### 3. The agent self-corrects
@@ -294,23 +291,27 @@ The same contract will support checks like:
 
 ```yaml
 checks:
-  # Keep functions simple
-  cognitive-complexity:
+  # Detect hidden dependencies from change patterns
+  change-coupling:
+    window: 90d
+    min-commits: 10
     thresholds:
-      warn: 10
-      fail: 20
+      warn: 30    # coupling degree %
+      fail: 60
 
-  # Don't let coverage erode
-  test-coverage-delta:
+  # Don't let coverage drift, ...
+  test-coverage-drift:
     thresholds:
       warn: -5
       fail: -15
 
-  # Respect the error budget
-  error-budget:
+  # Catch latency regressions
+  service-latency:
+    percentile: p99
+    window: 7d
     thresholds:
-      warn: 20
-      fail: 0
+      warn: 150   # ms
+      fail: 300
 ```
 
 Think of it like OpenTelemetry for fitness checks. OTel standardized
@@ -383,14 +384,14 @@ vision, principles, roadmap, and architecture decisions.
 
 **What's done:**
 
-- 3 checks: `commit-message`, `code-similarity`, `dependency-freshness`
+- 4 checks: `code-complexity`, `code-similarity`, `commit-message`, `dependency-freshness`
 - CLI with structured JSON output
 - MCP server for coding agent integration
 - Agent self-correction workflow (fail → read evidence → fix → pass)
 
 **What's next:**
 
-- More checks (cognitive complexity, circular dependencies, layer dependency)
+- More checks (circular dependencies, layer dependency)
 - Broader ecosystem support (deno, node, java, etc.)
 - Trend tracking (delta-from-baseline, direction over time)
 

--- a/crates/scute-core/src/code_complexity/check.rs
+++ b/crates/scute-core/src/code_complexity/check.rs
@@ -8,10 +8,23 @@ use crate::{Evaluation, Evidence, ExecutionError, Expected, Thresholds};
 
 pub const CHECK_NAME: &str = "code-complexity";
 
+/// Configuration for the code complexity check.
+///
+/// All fields are optional and fall back to sensible defaults when absent.
+///
+/// ```
+/// use scute_core::code_complexity::Definition;
+///
+/// // Zero-config: warn at 5, fail at 10
+/// let default = Definition::default();
+/// ```
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Definition {
+    /// Warn/fail boundaries for per-function complexity scores.
+    /// Defaults to warn: 5, fail: 10.
     pub thresholds: Option<Thresholds>,
+    /// Glob patterns for files to exclude from scanning.
     pub exclude: Option<Vec<String>>,
 }
 
@@ -24,6 +37,28 @@ impl Definition {
     }
 }
 
+/// Score cognitive complexity for every Rust function in a directory.
+///
+/// Discovers `.rs` files, parses each one with tree-sitter, and returns
+/// one [`Evaluation`] per function found. When no Rust files exist,
+/// returns a single passing evaluation.
+///
+/// When `focus_files` is non-empty, only functions from those files are
+/// reported. An empty slice means full-project scan. Focus files with
+/// unsupported extensions or that don't exist produce errored evaluations.
+///
+/// ```no_run
+/// use std::path::Path;
+/// use scute_core::code_complexity::{self, Definition};
+///
+/// let evals = code_complexity::check(Path::new("."), &[], &Definition::default()).unwrap();
+/// for eval in &evals {
+///     if eval.is_fail() {
+///         eprintln!("complex function: {}", eval.target);
+///     }
+/// }
+/// ```
+///
 /// # Errors
 ///
 /// Returns `ExecutionError` if `source_dir` is not a valid directory.

--- a/crates/scute-core/src/code_complexity/mod.rs
+++ b/crates/scute-core/src/code_complexity/mod.rs
@@ -1,3 +1,30 @@
+//! Cognitive complexity scoring for Rust functions.
+//!
+//! Scores each function based on how hard it is to understand, following
+//! [G. Ann Campbell's cognitive complexity spec](https://www.sonarsource.com/docs/CognitiveComplexity.pdf).
+//! Six cognitive drivers contribute to the score: flow breaks, nesting,
+//! else branches, boolean logic sequences, recursion, and labeled jumps.
+//!
+//! Nesting is the main multiplier: an `if` inside a `for` inside a `match`
+//! costs `1 + depth`, not just 1. Else-if chains are scored flat. Closures
+//! inherit the parent's nesting level.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use std::path::Path;
+//! use scute_core::code_complexity::{self, Definition};
+//!
+//! let results = code_complexity::check(
+//!     Path::new("."),
+//!     &[],                       // no focus files — score everything
+//!     &Definition::default(),    // warn: 5, fail: 10
+//! );
+//! ```
+//!
+//! Each function produces one [`Evaluation`](crate::Evaluation) with per-line
+//! [`Evidence`](crate::Evidence) entries explaining what drives the score.
+
 mod check;
 mod score;
 

--- a/docs/checks/code-complexity.md
+++ b/docs/checks/code-complexity.md
@@ -1,0 +1,203 @@
+# code-complexity
+
+## What it checks
+
+Scores each function's cognitive complexity following [G. Ann Campbell's
+spec](https://www.sonarsource.com/docs/CognitiveComplexity.pdf). Unlike
+cyclomatic complexity (which counts execution paths for testability), cognitive
+complexity measures how hard code is for a human to understand.
+
+## Why it matters
+
+Functions accumulate complexity one `if` at a time. By the time someone
+complains, the function is already 80 lines of nested spaghetti. Catching it
+per-function, per-commit keeps code reviewable and refactoring small.
+
+Coding agents are especially prone to piling logic into a single function.
+A clear score and per-line evidence gives them the signal they need to split
+things up before asking for review.
+
+## How scoring works
+
+Every function starts at 0. Six cognitive drivers add to the score:
+
+| Driver | Increment | When |
+| --- | --- | --- |
+| Flow break | +1 | `if`, `for`, `while`, `loop`, `match` at nesting depth 0 |
+| Nesting | +1 + depth | Same constructs, but nested inside other control flow |
+| Else | +1 | `else` or `else if` branch |
+| Boolean logic | +1 per sequence change | `a && b` = +1, `a && b \|\| c` = +2 |
+| Recursion | +1 | Direct recursive call |
+| Jump | +1 | Labeled `break` or `continue` |
+
+Key behaviors:
+
+- **Nesting multiplies.** An `if` inside a `for` inside a `match` costs 1 + nesting depth, not just 1. This is the main driver of high scores.
+- **Else-if chains are flat.** `if / else if / else if / else` does not compound nesting. Each branch costs +1.
+- **Closures inherit nesting.** A closure bumps nesting depth by 1 for its contained code. It's not a fresh scope.
+- **Logical operators count sequence changes.** `a && b && c` is one sequence (+1). `a && b || c && d` has two changes (+3).
+
+## Usage
+
+### CLI
+
+```sh
+scute check code-complexity [OPTIONS] [FILES]...
+```
+
+| Argument/Option      | Description                                                                       |
+| -------------------- | --------------------------------------------------------------------------------- |
+| `[FILES]...`         | Focus files. Only report findings for functions in these files. Reads from stdin if piped. |
+| `--source-dir <DIR>` | Directory to scan for source files. Defaults to the working directory.             |
+
+Scan the full project:
+
+```sh
+scute check code-complexity
+```
+
+Focus on specific files:
+
+```sh
+scute check code-complexity src/parser.rs src/engine.rs
+```
+
+Pipe changed files from git:
+
+```sh
+git diff --name-only HEAD~1 | scute check code-complexity
+```
+
+### MCP tool
+
+Tool name: `check_code_complexity`
+
+| Parameter    | Type            | Required | Description                                                       |
+| ------------ | --------------- | -------- | ----------------------------------------------------------------- |
+| `files`      | array\<string\> | no       | Focus files. Only report findings for functions in these files.    |
+| `source_dir` | string          | no       | Directory to scan for source files. Defaults to the project root. |
+
+## Configuration
+
+In your `.scute.yml`:
+
+```yaml
+checks:
+  code-complexity:
+    thresholds:
+      warn: 5
+      fail: 10
+    exclude:
+      - 'generated/**'
+```
+
+### Thresholds
+
+The `observed` value is the cognitive complexity score of a single function. One finding per function.
+
+| Threshold | Default | Description                                    |
+| --------- | ------- | ---------------------------------------------- |
+| `warn`    | `5`     | Warn when score > this value                   |
+| `fail`    | `10`    | Fail when score > this value                   |
+
+At score 5 you can follow the logic in one pass. At 10+ you need to re-read to track control flow. These defaults are calibrated for new code, not legacy.
+
+With defaults: score 5 passes, 6 warns, 10 warns, 11 fails.
+
+### Options
+
+| Option    | Type            | Default | Description                                    |
+| --------- | --------------- | ------- | ---------------------------------------------- |
+| `exclude` | array\<string\> | `[]`    | Glob patterns for files to skip during scanning |
+
+`exclude` patterns follow `.gitignore` semantics. Useful for generated code, vendored dependencies, or other directories you don't control.
+
+### Evidence rules
+
+Each line that contributes to a function's score produces an evidence entry. The `rule` field names the cognitive driver, `found` describes what's happening, and `expected` suggests what to do about it.
+
+| Rule | found example | expected |
+| --- | --- | --- |
+| `flow break` | `'for' loop (+1)` | — |
+| `nesting` | `'if' nested 2 levels: 'for > if > if' (+3)` | extract inner block into a function |
+| `else` | `'else' branch (+1)` | use a guard clause or early return |
+| `boolean logic` | `mixed '&&' and '\|\|' operators (+2)` | extract into a named boolean |
+| `recursion` | `recursive call to 'process' (+1)` | consider iterative approach |
+| `jump` | `'break' to label 'outer (+1)` | restructure to avoid labeled jump |
+
+The nesting chain reads left-to-right (outside to inside) and stops at closure boundaries: `'if' nested 2 levels: 'closure > if' (+3)`.
+
+## Examples
+
+### Warn: moderately complex function
+
+A function with nested control flow that's starting to get hard to follow:
+
+```sh
+scute check code-complexity src/process.rs
+```
+
+```json
+{
+  "check": "code-complexity",
+  "summary": { "evaluated": 4, "passed": 3, "warned": 1, "failed": 0, "errored": 0 },
+  "findings": [
+    {
+      "target": "src/process.rs:10:process",
+      "status": "warn",
+      "measurement": { "observed": 7, "thresholds": { "warn": 5, "fail": 10 } },
+      "evidence": [
+        {
+          "rule": "flow break",
+          "found": "'for' loop (+1)",
+          "location": "src/process.rs:11"
+        },
+        {
+          "rule": "nesting",
+          "found": "'if' nested 1 level: 'for > if' (+2)",
+          "expected": "extract inner block into a function",
+          "location": "src/process.rs:13"
+        },
+        {
+          "rule": "nesting",
+          "found": "'if' nested 2 levels: 'for > if > if' (+3)",
+          "expected": "extract inner block into a function",
+          "location": "src/process.rs:14"
+        },
+        {
+          "rule": "else",
+          "found": "'else' branch (+1)",
+          "expected": "use a guard clause or early return",
+          "location": "src/process.rs:17"
+        }
+      ]
+    }
+  ]
+}
+```
+
+The `target` is `file:line:function_name`. Each evidence entry points to a specific line, names the cognitive driver, shows its cost, and suggests a fix. An agent can read this and extract the nested block into a helper function.
+
+### Pass: simple functions
+
+```sh
+scute check code-complexity src/utils.rs
+```
+
+```json
+{
+  "check": "code-complexity",
+  "summary": { "evaluated": 3, "passed": 3, "warned": 0, "failed": 0, "errored": 0 },
+  "findings": []
+}
+```
+
+All functions score within thresholds. Nothing to fix.
+
+## Scope & limitations
+
+- **Supported languages:** Rust. TypeScript and JavaScript support is planned.
+- **Per-function, not per-file.** Each function is evaluated and reported independently. The `target` includes the function name and line number.
+- **Structural, not semantic.** Measures control flow structure. Two functions that are equally hard to understand but use different constructs may score differently.
+- **Focus vs. scan.** The `files` parameter focuses the *results* (only report functions from those files), but the full project is always scanned. You're filtering the report, not the search.
+- **Graceful with syntax errors.** Tree-sitter recovers from parse errors. Malformed code won't crash the check.

--- a/handbook/roadmap.md
+++ b/handbook/roadmap.md
@@ -5,11 +5,11 @@
 - Check engine, CLI, structured JSON output
 - MCP server as a first-class interface
 - Agent workflow integration (fail → evidence → self-correct → pass)
-- 3 checks: commit-message, code-similarity, dependency-freshness
+- 4 checks: code-complexity, code-similarity, commit-message, dependency-freshness
 
 ## Phase 2: Expand
 
-- More checks: cognitive complexity, circular dependencies, layer dependency
+- More checks: circular dependencies, layer dependency, change coupling
 - Broader ecosystem: deno/pnpm support for existing checks, npm
   dependency-freshness
 - Scope resolution (standardized approach for changed-files, staged, PR diff,


### PR DESCRIPTION
## Summary

- New `docs/checks/code-complexity.md` following the existing check doc pattern: scoring rules, CLI/MCP usage, configuration, evidence rules, examples, scope & limitations
- README: add code-complexity to checks table (reordered alphabetically), refresh vision section with `change-coupling`/`test-coverage-drift`/`service-latency`, tighten agent integration snippet with per-tool "when to use" hints, update status counts
- Rustdoc: module-level docs for `code_complexity`, struct/function docs for `Definition` and `check()`
- Roadmap: reflect 4 checks in Phase 1, move cognitive complexity out of Phase 2, add change coupling

Part of #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)