### PR TITLE
ci: add code-complexity check to PR workflow

### DIFF
--- a/.github/workflows/ci-scute.yml
+++ b/.github/workflows/ci-scute.yml
@@ -49,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         run: rustup show
@@ -58,8 +60,10 @@ jobs:
         with:
           workspaces: crates
 
-      - name: Check for duplication
-        run: $SCUTE check code-similarity
+      - name: Check for duplication in changed files
+        env:
+          BASE: origin/${{ github.base_ref }}
+        run: git diff --name-only $BASE...HEAD -- '*.rs' | $SCUTE check code-similarity
         working-directory: crates
 
   code-complexity:


### PR DESCRIPTION
## Summary

- Add `code-complexity` job to CI, scoped to changed `.rs` files on PRs
- Extract `SCUTE` env var for reusable `cargo run -q --` across jobs
- Refactor `code-similarity` job to use `$SCUTE` and `working-directory`

Note: changed files are filtered to `*.rs` because Scute currently errors on unsupported file types (#60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)