### PR TITLE
refactor(test-utils): extract write_source_files from setup_at

### DIFF
--- a/crates/scute-test-utils/src/project.rs
+++ b/crates/scute-test-utils/src/project.rs
@@ -150,13 +150,7 @@ impl TestProject {
             ),
             ProjectKind::Empty => {}
         }
-        for (name, content) in &self.source_files {
-            let path = root.join(name);
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent).unwrap();
-            }
-            std::fs::write(path, content).unwrap();
-        }
+        write_source_files(root, &self.source_files);
         if let Some(yaml) = &self.scute_config {
             std::fs::write(root.join(".scute.yml"), yaml).unwrap();
         }
@@ -318,6 +312,16 @@ fn append_js_deps(
                 .collect();
             pkg.insert(key.into(), map.into());
         }
+    }
+}
+
+fn write_source_files(root: &Path, files: &[(String, String)]) {
+    for (name, content) in files {
+        let path = root.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
     }
 }
 


### PR DESCRIPTION
## Summary

- Extracts the file-writing loop from `setup_at` into a standalone `write_source_files` function
- Reduces `setup_at`'s complexity score from 7 to 4, keeping it well under the warning threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)