### PR TITLE
refactor(code-similarity): flatten collect_tokens complexity

### DIFF
--- a/crates/scute-core/src/code_similarity/tokenize.rs
+++ b/crates/scute-core/src/code_similarity/tokenize.rs
@@ -53,44 +53,54 @@ pub fn tokenize(
     Ok(tokens)
 }
 
+enum TokenAction {
+    /// Emit this token and stop recursing.
+    Emit(Token),
+    /// Skip this node entirely (comments, decorations).
+    Skip,
+    /// Recurse into children.
+    Recurse,
+}
+
+fn classify_node(node: &tree_sitter::Node, source: &[u8], config: &LanguageConfig) -> TokenAction {
+    if node.is_error() || node.is_missing() {
+        return TokenAction::Skip;
+    }
+
+    if !node.is_named() {
+        return if node.child_count() == 0 {
+            TokenAction::Emit(Token::new(node.kind(), node))
+        } else {
+            TokenAction::Recurse
+        };
+    }
+
+    match config.classify(node.kind()) {
+        NodeRole::Identifier => TokenAction::Emit(Token::new("$ID", node)),
+        NodeRole::Literal => TokenAction::Emit(Token::new("$LIT", node)),
+        NodeRole::Comment | NodeRole::Decoration => TokenAction::Skip,
+        NodeRole::Other if node.child_count() == 0 => {
+            let text = node.utf8_text(source).unwrap_or("");
+            TokenAction::Emit(Token::new(text, node))
+        }
+        NodeRole::Other => TokenAction::Recurse,
+    }
+}
+
 fn collect_tokens(
     node: tree_sitter::Node,
     source: &[u8],
     config: &LanguageConfig,
     tokens: &mut Vec<Token>,
 ) {
-    if node.is_error() || node.is_missing() {
-        return;
-    }
-
-    if node.is_named() {
-        match config.classify(node.kind()) {
-            NodeRole::Identifier => {
-                tokens.push(Token::new("$ID", &node));
-                return;
-            }
-            NodeRole::Literal => {
-                tokens.push(Token::new("$LIT", &node));
-                return;
-            }
-            NodeRole::Comment | NodeRole::Decoration => return,
-            NodeRole::Other => {
-                if node.child_count() == 0 {
-                    let text = node.utf8_text(source).unwrap_or("");
-                    tokens.push(Token::new(text, &node));
-                    return;
-                }
+    match classify_node(&node, source, config) {
+        TokenAction::Emit(token) => tokens.push(token),
+        TokenAction::Skip => {}
+        TokenAction::Recurse => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                collect_tokens(child, source, config, tokens);
             }
         }
-    }
-
-    if node.child_count() == 0 {
-        tokens.push(Token::new(node.kind(), &node));
-        return;
-    }
-
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        collect_tokens(child, source, config, tokens);
     }
 }


### PR DESCRIPTION
## Summary

- Extracted node classification logic from `collect_tokens` into a new `classify_node` function that returns a `TokenAction` enum (`Emit`, `Skip`, `Recurse`)
- `collect_tokens` is now a flat match over the action, dropping its complexity score from 11 (fail) to 4 (pass)
- `classify_node` scores 7 (warn), well within the fail threshold of 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)