### PR TITLE
refactor: eliminate all remaining complexity warnings

### DIFF
--- a/crates/scute-core/src/code_similarity/detect.rs
+++ b/crates/scute-core/src/code_similarity/detect.rs
@@ -202,13 +202,9 @@ fn pop_and_record(
     min_tokens: usize,
 ) -> usize {
     let mut lb = i - 1;
-    while let Some(&(d, _)) = stack.last() {
-        if cur >= d {
-            break;
-        }
+    while stack.last().is_some_and(|&(d, _)| d > cur) {
         let (depth, left) = stack.pop().unwrap();
         lb = left;
-
         if depth >= min_tokens && i - 1 > left {
             intervals.push((depth, left, i - 1));
         }
@@ -232,13 +228,17 @@ fn extract_lcp_intervals(
     // the algorithm.
     #[allow(clippy::needless_range_loop)]
     for i in 1..=n {
-        let cur = if i < n { lcp[i] } else { 0 };
+        let cur = lcp.get(i).copied().unwrap_or(0);
         let lb = pop_and_record(&mut stack, &mut intervals, cur, i, min_tokens);
 
-        if cur >= min_tokens && (stack.is_empty() || cur > stack.last().unwrap().0) {
+        if should_push_interval(cur, min_tokens, &stack) {
             stack.push((cur, lb));
         }
     }
 
     intervals
+}
+
+fn should_push_interval(cur: usize, min_tokens: usize, stack: &[(usize, usize)]) -> bool {
+    cur >= min_tokens && stack.last().is_none_or(|&(d, _)| cur > d)
 }

--- a/crates/scute-core/src/code_similarity/tokenize.rs
+++ b/crates/scute-core/src/code_similarity/tokenize.rs
@@ -68,13 +68,25 @@ fn classify_node(node: &tree_sitter::Node, source: &[u8], config: &LanguageConfi
     }
 
     if !node.is_named() {
-        return if node.child_count() == 0 {
-            TokenAction::Emit(Token::new(node.kind(), node))
-        } else {
-            TokenAction::Recurse
-        };
+        return classify_unnamed(node);
     }
 
+    classify_by_role(node, source, config)
+}
+
+fn classify_unnamed(node: &tree_sitter::Node) -> TokenAction {
+    if node.child_count() == 0 {
+        TokenAction::Emit(Token::new(node.kind(), node))
+    } else {
+        TokenAction::Recurse
+    }
+}
+
+fn classify_by_role(
+    node: &tree_sitter::Node,
+    source: &[u8],
+    config: &LanguageConfig,
+) -> TokenAction {
     match config.classify(node.kind()) {
         NodeRole::Identifier => TokenAction::Emit(Token::new("$ID", node)),
         NodeRole::Literal => TokenAction::Emit(Token::new("$LIT", node)),

--- a/crates/scute-core/src/dependency_freshness/npm/mod.rs
+++ b/crates/scute-core/src/dependency_freshness/npm/mod.rs
@@ -62,11 +62,7 @@ fn parse_outdated(
             _ => continue,
         };
 
-        for entry in entries {
-            if let Some(dependency) = parse_entry(name, entry, layout) {
-                outdated.push(dependency);
-            }
-        }
+        outdated.extend(entries.iter().filter_map(|e| parse_entry(name, e, layout)));
     }
 
     Ok(outdated)

--- a/crates/scute-core/src/dependency_freshness/pnpm/mod.rs
+++ b/crates/scute-core/src/dependency_freshness/pnpm/mod.rs
@@ -22,12 +22,7 @@ impl PackageManager for Pnpm {
             String::from_utf8(output.stdout).map_err(|e| FetchError::Failed(e.to_string()))?;
 
         if stdout.trim().is_empty() || stdout.trim() == "{}" {
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                if !stderr.trim().is_empty() {
-                    return Err(FetchError::Failed(stderr.trim().to_string()));
-                }
-            }
+            check_for_silent_failure(output.status, &output.stderr)?;
             return Ok(vec![]);
         }
 
@@ -39,6 +34,22 @@ impl PackageManager for Pnpm {
 
         parse_outdated(&stdout, &root)
     }
+}
+
+/// pnpm exits non-zero with empty stdout when it genuinely fails.
+/// Distinguish that from "no outdated deps" by checking stderr.
+fn check_for_silent_failure(
+    status: std::process::ExitStatus,
+    stderr: &[u8],
+) -> Result<(), FetchError> {
+    if status.success() {
+        return Ok(());
+    }
+    let msg = String::from_utf8_lossy(stderr);
+    if !msg.trim().is_empty() {
+        return Err(FetchError::Failed(msg.trim().to_string()));
+    }
+    Ok(())
 }
 
 fn parse_outdated(json: &str, root: &Path) -> Result<Vec<OutdatedDependency>, FetchError> {

--- a/crates/scute-test-utils/src/project.rs
+++ b/crates/scute-test-utils/src/project.rs
@@ -340,12 +340,13 @@ fn append_cargo_deps(
     for (section, deps) in [
         ("[dependencies]", dependencies),
         ("[dev-dependencies]", dev_dependencies),
-    ] {
-        if !deps.is_empty() {
-            writeln!(toml, "\n{section}").unwrap();
-            for (name, version) in deps {
-                writeln!(toml, "{name} = \"{version}\"").unwrap();
-            }
+    ]
+    .into_iter()
+    .filter(|(_, deps)| !deps.is_empty())
+    {
+        writeln!(toml, "\n{section}").unwrap();
+        for (name, version) in deps {
+            writeln!(toml, "{name} = \"{version}\"").unwrap();
         }
     }
 }


### PR DESCRIPTION
## Summary

Brings the codebase from 6 warns to **0 warns, 0 fails** (585/585 pass).

Each fix addresses the underlying design issue, not just the score:

- **detect.rs**: `while let + if break` → `is_some_and` predicate, inline ternary → `lcp.get().unwrap_or()`, compound boolean → extracted `should_push_interval`
- **tokenize.rs**: mixed concerns (error filtering + role dispatch) → split into `classify_unnamed` + `classify_by_role`
- **npm/mod.rs**: manual `for + if let + push` → `filter_map` + `extend`
- **pnpm/mod.rs**: nested error diagnosis → extracted `check_for_silent_failure`
- **project.rs**: `if !empty` guard inside loop → `.filter()` on the iterator

🤖 Generated with [Claude Code](https://claude.com/claude-code)