### PR TITLE
fix(ci): use --relative in git diff so paths match working-directory

### DIFF
--- a/.github/workflows/ci-scute.yml
+++ b/.github/workflows/ci-scute.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Check for duplication in changed files
         env:
           BASE: origin/${{ github.base_ref }}
-        run: git diff --name-only $BASE...HEAD -- '*.rs' | $SCUTE check code-similarity
+        run: git diff --name-only --relative $BASE...HEAD -- '*.rs' | $SCUTE check code-similarity
         working-directory: crates
 
   code-complexity:
@@ -86,5 +86,5 @@ jobs:
       - name: Check complexity of changed files
         env:
           BASE: origin/${{ github.base_ref }}
-        run: git diff --name-only $BASE...HEAD -- '*.rs' | $SCUTE check code-complexity
+        run: git diff --name-only --relative $BASE...HEAD -- '*.rs' | $SCUTE check code-complexity
         working-directory: crates


### PR DESCRIPTION
## Summary

- `git diff --name-only` outputs paths relative to repo root (e.g. `crates/scute-core/src/...`), but the CI steps run with `working-directory: crates`. This caused the checks to resolve paths as `crates/crates/...`. Adding `--relative` makes git output paths relative to the current directory, matching the working directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)