### PR TITLE
refactor(code-complexity): language-agnostic scoring engine

### DIFF
--- a/crates/scute-core/src/code_complexity/check.rs
+++ b/crates/scute-core/src/code_complexity/check.rs
@@ -2,7 +2,8 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use super::score;
+use super::rules::LanguageRules;
+use super::{rust, score};
 use crate::files;
 use crate::{Evaluation, Evidence, ExecutionError, Expected, Thresholds};
 
@@ -76,7 +77,7 @@ pub fn check(
         recovery: "check that the path exists and is readable".into(),
     })?;
 
-    let rules = score::Rust;
+    let rules = rust::Rust;
     let mut evaluations = Vec::new();
 
     for path in &files {
@@ -99,7 +100,7 @@ pub fn check(
 fn score_file(
     path: &Path,
     source: &str,
-    rules: &dyn score::LanguageRules,
+    rules: &dyn LanguageRules,
     thresholds: &Thresholds,
 ) -> Vec<Evaluation> {
     score::score_functions(source, rules)

--- a/crates/scute-core/src/code_complexity/mod.rs
+++ b/crates/scute-core/src/code_complexity/mod.rs
@@ -25,6 +25,8 @@
 //! [`Evidence`](crate::Evidence) entries explaining what drives the score.
 
 mod check;
+mod rules;
+mod rust;
 mod score;
 
 pub use check::{CHECK_NAME, Definition, check};

--- a/crates/scute-core/src/code_complexity/rules.rs
+++ b/crates/scute-core/src/code_complexity/rules.rs
@@ -1,0 +1,79 @@
+use tree_sitter::Language;
+
+use super::score::{Construct, JumpKeyword, LogicalOp};
+
+pub enum NodeRole {
+    FlowConstruct(Construct),
+    ElseClause,
+    NestingBoundary,
+    LogicalExpression,
+    LabeledJump(JumpKeyword, String),
+    RecursiveCall,
+}
+
+pub enum NestingKind {
+    /// Increases nesting, part of enclosing function (closures, arrow functions).
+    /// The construct appears in nesting chains.
+    Inline(Construct),
+    /// Increases nesting in outer function, scored independently at depth 0.
+    Separate,
+}
+
+pub struct ScoringUnit<'a> {
+    pub name: String,
+    pub line: usize,
+    pub node: tree_sitter::Node<'a>,
+    pub receiver_type: Option<String>,
+}
+
+/// Maps a language's tree-sitter AST to cognitive complexity drivers.
+///
+/// The scoring algorithm is language-agnostic: it asks the language to identify
+/// its own constructs (flow control, nesting boundaries, logical operators, etc.)
+/// and applies the Sonar cognitive complexity rules uniformly.
+pub trait LanguageRules {
+    /// The tree-sitter grammar for this language.
+    fn language(&self) -> Language;
+
+    /// If this node is a scoreable function or method, return its metadata.
+    fn scoring_unit<'a>(
+        &self,
+        node: tree_sitter::Node<'a>,
+        src: &'a [u8],
+    ) -> Option<ScoringUnit<'a>>;
+
+    /// If this node is a flow control construct (`if`, `for`, `match`, etc.),
+    /// return which one. These get a structural increment of `1 + nesting`.
+    fn flow_construct(&self, node: tree_sitter::Node) -> Option<Construct>;
+
+    /// Whether this node is an else clause (scores +1 as a hybrid increment).
+    fn is_else_clause(&self, node: tree_sitter::Node) -> bool;
+
+    /// Whether this else clause is actually an else-if (scored flat, no nesting penalty).
+    fn is_else_if(&self, node: tree_sitter::Node) -> bool;
+
+    /// If this node is a nesting boundary (closure, arrow function, nested
+    /// named function), return how it affects scoring.
+    fn nesting_kind(&self, node: tree_sitter::Node) -> Option<NestingKind>;
+
+    /// If this node is a logical expression, return which operator it uses.
+    /// Used to count operator sequences.
+    fn logical_operator(&self, node: tree_sitter::Node) -> Option<LogicalOp>;
+
+    /// Whether this node is a logical operator token (`&&`, `||`).
+    /// Used to filter operands when walking logical expression trees.
+    fn is_logical_operator_token(&self, node: tree_sitter::Node) -> bool;
+
+    /// If this node is a labeled jump (`break 'label`, `continue 'label`),
+    /// return the keyword and label text. Scores +1 as a hybrid increment.
+    fn jump_label(&self, node: tree_sitter::Node, src: &[u8]) -> Option<(JumpKeyword, String)>;
+
+    /// Whether this node is a direct recursive call to the function being scored.
+    fn is_recursive_call(
+        &self,
+        node: tree_sitter::Node,
+        fn_name: &str,
+        receiver_type: Option<&str>,
+        src: &[u8],
+    ) -> bool;
+}

--- a/crates/scute-core/src/code_complexity/rust.rs
+++ b/crates/scute-core/src/code_complexity/rust.rs
@@ -1,0 +1,135 @@
+use tree_sitter::Language;
+
+use super::rules::{LanguageRules, NestingKind, ScoringUnit};
+use super::score::{Construct, JumpKeyword, LogicalOp};
+
+pub struct Rust;
+
+impl LanguageRules for Rust {
+    fn language(&self) -> Language {
+        tree_sitter_rust::LANGUAGE.into()
+    }
+
+    fn scoring_unit<'a>(
+        &self,
+        node: tree_sitter::Node<'a>,
+        src: &'a [u8],
+    ) -> Option<ScoringUnit<'a>> {
+        if node.kind() != "function_item" {
+            return None;
+        }
+        let name = node
+            .child_by_field_name("name")
+            .and_then(|n| n.utf8_text(src).ok())
+            .unwrap_or("")
+            .to_string();
+        let receiver_type = enclosing_impl_type(node, src);
+        Some(ScoringUnit {
+            name,
+            line: node.start_position().row + 1,
+            node,
+            receiver_type,
+        })
+    }
+
+    fn flow_construct(&self, node: tree_sitter::Node) -> Option<Construct> {
+        match node.kind() {
+            "if_expression" => Some(Construct::If),
+            "for_expression" => Some(Construct::For),
+            "while_expression" => Some(Construct::While),
+            "loop_expression" => Some(Construct::Loop),
+            "match_expression" => Some(Construct::Match),
+            _ => None,
+        }
+    }
+
+    fn is_else_clause(&self, node: tree_sitter::Node) -> bool {
+        node.kind() == "else_clause"
+    }
+
+    fn is_else_if(&self, node: tree_sitter::Node) -> bool {
+        node.children(&mut node.walk())
+            .any(|c| c.kind() == "if_expression")
+    }
+
+    fn nesting_kind(&self, node: tree_sitter::Node) -> Option<NestingKind> {
+        match node.kind() {
+            "closure_expression" => Some(NestingKind::Inline(Construct::Closure)),
+            "function_item" => Some(NestingKind::Separate),
+            _ => None,
+        }
+    }
+
+    fn logical_operator(&self, node: tree_sitter::Node) -> Option<LogicalOp> {
+        if node.kind() != "binary_expression" {
+            return None;
+        }
+        node.children(&mut node.walk())
+            .find(|c| c.kind() == "&&" || c.kind() == "||")
+            .map(|c| match c.kind() {
+                "&&" => LogicalOp::And("&&"),
+                _ => LogicalOp::Or("||"),
+            })
+    }
+
+    fn is_logical_operator_token(&self, node: tree_sitter::Node) -> bool {
+        node.kind() == "&&" || node.kind() == "||"
+    }
+
+    fn jump_label(&self, node: tree_sitter::Node, src: &[u8]) -> Option<(JumpKeyword, String)> {
+        let keyword = match node.kind() {
+            "break_expression" => JumpKeyword::Break,
+            "continue_expression" => JumpKeyword::Continue,
+            _ => return None,
+        };
+        let label = node
+            .children(&mut node.walk())
+            .find(|c| c.kind() == "label")
+            .and_then(|l| l.utf8_text(src).ok())?;
+        Some((keyword, label.to_string()))
+    }
+
+    fn is_recursive_call(
+        &self,
+        node: tree_sitter::Node,
+        fn_name: &str,
+        receiver_type: Option<&str>,
+        src: &[u8],
+    ) -> bool {
+        if node.kind() != "call_expression" {
+            return false;
+        }
+        let Some(target) = node.child_by_field_name("function") else {
+            return false;
+        };
+        callee_name(target, src) == Some(fn_name) && scope_is_self(target, receiver_type, src)
+    }
+}
+
+fn enclosing_impl_type(node: tree_sitter::Node, src: &[u8]) -> Option<String> {
+    std::iter::successors(node.parent(), tree_sitter::Node::parent)
+        .find(|n| n.kind() == "impl_item")
+        .and_then(|n| n.child_by_field_name("type"))
+        .and_then(|t| t.utf8_text(src).ok())
+        .map(String::from)
+}
+
+fn callee_name<'a>(target: tree_sitter::Node, src: &'a [u8]) -> Option<&'a str> {
+    match target.kind() {
+        "field_expression" => field_text(target, "field", src), // self.foo()
+        "scoped_identifier" => field_text(target, "name", src), // Self::foo()
+        _ => target.utf8_text(src).ok(),                        // foo()
+    }
+}
+
+fn scope_is_self(target: tree_sitter::Node, impl_type: Option<&str>, src: &[u8]) -> bool {
+    if target.kind() != "scoped_identifier" {
+        return true;
+    }
+    field_text(target, "path", src).is_some_and(|scope| scope == "Self" || impl_type == Some(scope))
+}
+
+fn field_text<'a>(node: tree_sitter::Node, field: &str, src: &'a [u8]) -> Option<&'a str> {
+    node.child_by_field_name(field)
+        .and_then(|n| n.utf8_text(src).ok())
+}

--- a/crates/scute-core/src/code_complexity/score.rs
+++ b/crates/scute-core/src/code_complexity/score.rs
@@ -1,209 +1,6 @@
 use crate::parser::{AstParser, TreeSitterParser};
-use tree_sitter::Language;
 
-pub enum NodeRole {
-    FlowConstruct(Construct),
-    ElseClause,
-    NestingBoundary,
-    LogicalExpression,
-    LabeledJump(JumpKeyword, String),
-    RecursiveCall,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum LogicalOp {
-    And(&'static str),
-    Or(&'static str),
-}
-
-impl LogicalOp {
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::And(s) | Self::Or(s) => s,
-        }
-    }
-}
-
-impl PartialEq for LogicalOp {
-    fn eq(&self, other: &Self) -> bool {
-        matches!(
-            (self, other),
-            (Self::And(_), Self::And(_)) | (Self::Or(_), Self::Or(_))
-        )
-    }
-}
-
-impl Eq for LogicalOp {}
-
-pub enum NestingKind {
-    /// Increases nesting, part of enclosing function (closures, arrow functions).
-    /// The construct appears in nesting chains.
-    Inline(Construct),
-    /// Increases nesting in outer function, scored independently at depth 0.
-    Separate,
-}
-
-/// Maps a language's tree-sitter AST to cognitive complexity drivers.
-///
-/// The scoring algorithm is language-agnostic: it asks the language to identify
-/// its own constructs (flow control, nesting boundaries, logical operators, etc.)
-/// and applies the Sonar cognitive complexity rules uniformly.
-pub trait LanguageRules {
-    /// The tree-sitter grammar for this language.
-    fn language(&self) -> Language;
-
-    /// If this node is a scoreable function or method, return its metadata.
-    fn scoring_unit<'a>(
-        &self,
-        node: tree_sitter::Node<'a>,
-        src: &'a [u8],
-    ) -> Option<ScoringUnit<'a>>;
-
-    /// If this node is a flow control construct (`if`, `for`, `match`, etc.),
-    /// return which one. These get a structural increment of `1 + nesting`.
-    fn flow_construct(&self, node: tree_sitter::Node) -> Option<Construct>;
-
-    /// Whether this node is an else clause (scores +1 as a hybrid increment).
-    fn is_else_clause(&self, node: tree_sitter::Node) -> bool;
-
-    /// Whether this else clause is actually an else-if (scored flat, no nesting penalty).
-    fn is_else_if(&self, node: tree_sitter::Node) -> bool;
-
-    /// If this node is a nesting boundary (closure, arrow function, nested
-    /// named function), return how it affects scoring.
-    fn nesting_kind(&self, node: tree_sitter::Node) -> Option<NestingKind>;
-
-    /// If this node is a logical expression, return which operator it uses.
-    /// Used to count operator sequences.
-    fn logical_operator(&self, node: tree_sitter::Node) -> Option<LogicalOp>;
-
-    /// Whether this node is a logical operator token (`&&`, `||`).
-    /// Used to filter operands when walking logical expression trees.
-    fn is_logical_operator_token(&self, node: tree_sitter::Node) -> bool;
-
-    /// If this node is a labeled jump (`break 'label`, `continue 'label`),
-    /// return the keyword and label text. Scores +1 as a hybrid increment.
-    fn jump_label(&self, node: tree_sitter::Node, src: &[u8]) -> Option<(JumpKeyword, String)>;
-
-    /// Whether this node is a direct recursive call to the function being scored.
-    fn is_recursive_call(
-        &self,
-        node: tree_sitter::Node,
-        fn_name: &str,
-        receiver_type: Option<&str>,
-        src: &[u8],
-    ) -> bool;
-}
-
-pub struct ScoringUnit<'a> {
-    pub name: String,
-    pub line: usize,
-    pub node: tree_sitter::Node<'a>,
-    pub receiver_type: Option<String>,
-}
-
-pub struct Rust;
-
-impl LanguageRules for Rust {
-    fn language(&self) -> Language {
-        tree_sitter_rust::LANGUAGE.into()
-    }
-
-    fn scoring_unit<'a>(
-        &self,
-        node: tree_sitter::Node<'a>,
-        src: &'a [u8],
-    ) -> Option<ScoringUnit<'a>> {
-        if node.kind() != "function_item" {
-            return None;
-        }
-        let name = node
-            .child_by_field_name("name")
-            .and_then(|n| n.utf8_text(src).ok())
-            .unwrap_or("")
-            .to_string();
-        let receiver_type = enclosing_impl_type(node, src);
-        Some(ScoringUnit {
-            name,
-            line: node.start_position().row + 1,
-            node,
-            receiver_type,
-        })
-    }
-
-    fn flow_construct(&self, node: tree_sitter::Node) -> Option<Construct> {
-        match node.kind() {
-            "if_expression" => Some(Construct::If),
-            "for_expression" => Some(Construct::For),
-            "while_expression" => Some(Construct::While),
-            "loop_expression" => Some(Construct::Loop),
-            "match_expression" => Some(Construct::Match),
-            _ => None,
-        }
-    }
-
-    fn is_else_clause(&self, node: tree_sitter::Node) -> bool {
-        node.kind() == "else_clause"
-    }
-
-    fn is_else_if(&self, node: tree_sitter::Node) -> bool {
-        node.children(&mut node.walk())
-            .any(|c| c.kind() == "if_expression")
-    }
-
-    fn nesting_kind(&self, node: tree_sitter::Node) -> Option<NestingKind> {
-        match node.kind() {
-            "closure_expression" => Some(NestingKind::Inline(Construct::Closure)),
-            "function_item" => Some(NestingKind::Separate),
-            _ => None,
-        }
-    }
-
-    fn logical_operator(&self, node: tree_sitter::Node) -> Option<LogicalOp> {
-        if node.kind() != "binary_expression" {
-            return None;
-        }
-        node.children(&mut node.walk())
-            .find(|c| c.kind() == "&&" || c.kind() == "||")
-            .map(|c| match c.kind() {
-                "&&" => LogicalOp::And("&&"),
-                _ => LogicalOp::Or("||"),
-            })
-    }
-
-    fn is_logical_operator_token(&self, node: tree_sitter::Node) -> bool {
-        node.kind() == "&&" || node.kind() == "||"
-    }
-
-    fn jump_label(&self, node: tree_sitter::Node, src: &[u8]) -> Option<(JumpKeyword, String)> {
-        let keyword = match node.kind() {
-            "break_expression" => JumpKeyword::Break,
-            "continue_expression" => JumpKeyword::Continue,
-            _ => return None,
-        };
-        let label = node
-            .children(&mut node.walk())
-            .find(|c| c.kind() == "label")
-            .and_then(|l| l.utf8_text(src).ok())?;
-        Some((keyword, label.to_string()))
-    }
-
-    fn is_recursive_call(
-        &self,
-        node: tree_sitter::Node,
-        fn_name: &str,
-        receiver_type: Option<&str>,
-        src: &[u8],
-    ) -> bool {
-        if node.kind() != "call_expression" {
-            return false;
-        }
-        let Some(target) = node.child_by_field_name("function") else {
-            return false;
-        };
-        callee_name(target, src) == Some(fn_name) && scope_is_self(target, receiver_type, src)
-    }
-}
+use super::rules::{LanguageRules, NestingKind, NodeRole, ScoringUnit};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Construct {
@@ -251,6 +48,31 @@ impl JumpKeyword {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+pub enum LogicalOp {
+    And(&'static str),
+    Or(&'static str),
+}
+
+impl LogicalOp {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::And(s) | Self::Or(s) => s,
+        }
+    }
+}
+
+impl PartialEq for LogicalOp {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::And(_), Self::And(_)) | (Self::Or(_), Self::Or(_))
+        )
+    }
+}
+
+impl Eq for LogicalOp {}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ContributorKind {
@@ -328,14 +150,6 @@ fn collect_functions(
         }
         collect_functions(child, src, rules, results);
     }
-}
-
-fn enclosing_impl_type(node: tree_sitter::Node, src: &[u8]) -> Option<String> {
-    std::iter::successors(node.parent(), tree_sitter::Node::parent)
-        .find(|n| n.kind() == "impl_item")
-        .and_then(|n| n.child_by_field_name("type"))
-        .and_then(|t| t.utf8_text(src).ok())
-        .map(String::from)
 }
 
 fn classify(
@@ -525,26 +339,6 @@ fn nesting_chain(node: tree_sitter::Node, rules: &dyn LanguageRules) -> Vec<Cons
     chain
 }
 
-fn callee_name<'a>(target: tree_sitter::Node, src: &'a [u8]) -> Option<&'a str> {
-    match target.kind() {
-        "field_expression" => field_text(target, "field", src), // self.foo()
-        "scoped_identifier" => field_text(target, "name", src), // Self::foo()
-        _ => target.utf8_text(src).ok(),                        // foo()
-    }
-}
-
-fn scope_is_self(target: tree_sitter::Node, impl_type: Option<&str>, src: &[u8]) -> bool {
-    if target.kind() != "scoped_identifier" {
-        return true;
-    }
-    field_text(target, "path", src).is_some_and(|scope| scope == "Self" || impl_type == Some(scope))
-}
-
-fn field_text<'a>(node: tree_sitter::Node, field: &str, src: &'a [u8]) -> Option<&'a str> {
-    node.child_by_field_name(field)
-        .and_then(|n| n.utf8_text(src).ok())
-}
-
 fn count_operator_sequences(operators: &[LogicalOp]) -> u64 {
     operators
         .windows(2)
@@ -574,6 +368,7 @@ fn collect_logical_operators(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::code_complexity::rust::Rust;
     use test_case::test_case;
 
     fn score_only(source: &str) -> u64 {


### PR DESCRIPTION
## Summary

- Introduced `LanguageRules` trait with 9 methods mapping to the Sonar cognitive complexity drivers
- Extracted `Rust` as the first implementor, all existing behavior preserved
- Scoring algorithm (`ScoringContext`) now delegates all node classification to the trait
- Added `NodeRole` enum + `classify` functions to dispatch scoring rules cleanly
- Added `NestingKind` enum (Inline/Separate) and `ScoringUnit` struct for function discovery
- Zero complexity warnings, zero similarity findings

Part of #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)