### PR TITLE
refactor(code-complexity): cognitive roles for Construct

### DIFF
--- a/crates/scute-core/src/code_complexity/check.rs
+++ b/crates/scute-core/src/code_complexity/check.rs
@@ -117,10 +117,10 @@ fn score_file(
         .collect()
 }
 
-fn format_nesting_chain(chain: &[score::Construct]) -> String {
+fn format_nesting_chain(chain: &[score::FlowConstruct]) -> String {
     chain
         .iter()
-        .map(|c| c.label())
+        .map(|c| c.label)
         .collect::<Vec<_>>()
         .join(" > ")
 }
@@ -146,8 +146,8 @@ fn format_evidence(c: &score::Contributor, path: &Path) -> Evidence {
             "flow break",
             format!(
                 "'{}' {} (+{})",
-                construct.label(),
-                construct.flow_break_label(),
+                construct.label,
+                construct.role.flow_break_category(),
                 c.increment
             ),
             None,
@@ -157,7 +157,7 @@ fn format_evidence(c: &score::Contributor, path: &Path) -> Evidence {
             depth,
             chain,
         } => {
-            let name = construct.label();
+            let name = construct.label;
             let chain = format_nesting_chain(chain);
             let levels = pluralize_levels(*depth);
             (

--- a/crates/scute-core/src/code_complexity/rules.rs
+++ b/crates/scute-core/src/code_complexity/rules.rs
@@ -1,9 +1,9 @@
 use tree_sitter::Language;
 
-use super::score::{Construct, JumpKeyword, LogicalOp};
+use super::score::{FlowConstruct, JumpKeyword, LogicalOp};
 
 pub enum NodeRole {
-    FlowConstruct(Construct),
+    FlowConstruct(FlowConstruct),
     ElseClause,
     NestingBoundary,
     LogicalExpression,
@@ -14,7 +14,7 @@ pub enum NodeRole {
 pub enum NestingKind {
     /// Increases nesting, part of enclosing function (closures, arrow functions).
     /// The construct appears in nesting chains.
-    Inline(Construct),
+    Inline(FlowConstruct),
     /// Increases nesting in outer function, scored independently at depth 0.
     Separate,
 }
@@ -43,8 +43,9 @@ pub trait LanguageRules {
     ) -> Option<ScoringUnit<'a>>;
 
     /// If this node is a flow control construct (`if`, `for`, `match`, etc.),
-    /// return which one. These get a structural increment of `1 + nesting`.
-    fn flow_construct(&self, node: tree_sitter::Node) -> Option<Construct>;
+    /// return its cognitive role and language-specific label.
+    /// These get a structural increment of `1 + nesting`.
+    fn flow_construct(&self, node: tree_sitter::Node) -> Option<FlowConstruct>;
 
     /// Whether this node is an else clause (scores +1 as a hybrid increment).
     fn is_else_clause(&self, node: tree_sitter::Node) -> bool;

--- a/crates/scute-core/src/code_complexity/rust.rs
+++ b/crates/scute-core/src/code_complexity/rust.rs
@@ -1,7 +1,7 @@
 use tree_sitter::Language;
 
 use super::rules::{LanguageRules, NestingKind, ScoringUnit};
-use super::score::{Construct, JumpKeyword, LogicalOp};
+use super::score::{Construct, FlowConstruct, JumpKeyword, LogicalOp};
 
 pub struct Rust;
 
@@ -32,13 +32,28 @@ impl LanguageRules for Rust {
         })
     }
 
-    fn flow_construct(&self, node: tree_sitter::Node) -> Option<Construct> {
+    fn flow_construct(&self, node: tree_sitter::Node) -> Option<FlowConstruct> {
         match node.kind() {
-            "if_expression" => Some(Construct::If),
-            "for_expression" => Some(Construct::For),
-            "while_expression" => Some(Construct::While),
-            "loop_expression" => Some(Construct::Loop),
-            "match_expression" => Some(Construct::Match),
+            "if_expression" => Some(FlowConstruct {
+                role: Construct::Conditional,
+                label: "if",
+            }),
+            "for_expression" => Some(FlowConstruct {
+                role: Construct::Loop,
+                label: "for",
+            }),
+            "while_expression" => Some(FlowConstruct {
+                role: Construct::Loop,
+                label: "while",
+            }),
+            "loop_expression" => Some(FlowConstruct {
+                role: Construct::Loop,
+                label: "loop",
+            }),
+            "match_expression" => Some(FlowConstruct {
+                role: Construct::Conditional,
+                label: "match",
+            }),
             _ => None,
         }
     }
@@ -54,7 +69,10 @@ impl LanguageRules for Rust {
 
     fn nesting_kind(&self, node: tree_sitter::Node) -> Option<NestingKind> {
         match node.kind() {
-            "closure_expression" => Some(NestingKind::Inline(Construct::Closure)),
+            "closure_expression" => Some(NestingKind::Inline(FlowConstruct {
+                role: Construct::InlineNesting,
+                label: "closure",
+            })),
             "function_item" => Some(NestingKind::Separate),
             _ => None,
         }

--- a/crates/scute-core/src/code_complexity/score.rs
+++ b/crates/scute-core/src/code_complexity/score.rs
@@ -1,37 +1,30 @@
 use crate::parser::{AstParser, TreeSitterParser};
 
-use super::rules::{LanguageRules, NestingKind, NodeRole, ScoringUnit};
+use super::rules::{LanguageRules, NestingKind, NodeRole};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Construct {
-    If,
-    For,
-    While,
+    Conditional,
     Loop,
-    Match,
-    Closure,
+    ExceptionHandler,
+    InlineNesting,
 }
 
 impl Construct {
-    pub fn label(self) -> &'static str {
+    pub fn flow_break_category(self) -> &'static str {
         match self {
-            Self::If => "if",
-            Self::For => "for",
-            Self::While => "while",
+            Self::Conditional => "conditional",
             Self::Loop => "loop",
-            Self::Match => "match",
-            Self::Closure => "closure",
+            Self::ExceptionHandler => "exception handler",
+            Self::InlineNesting => "closure",
         }
     }
+}
 
-    pub fn flow_break_label(self) -> &'static str {
-        match self {
-            Self::For | Self::While | Self::Loop => "loop",
-            Self::If => "conditional",
-            Self::Match => "expression",
-            Self::Closure => "closure",
-        }
-    }
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FlowConstruct {
+    pub role: Construct,
+    pub label: &'static str,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,12 +70,12 @@ impl Eq for LogicalOp {}
 #[derive(Debug, Clone, PartialEq)]
 pub enum ContributorKind {
     FlowBreak {
-        construct: Construct,
+        construct: FlowConstruct,
     },
     Nesting {
-        construct: Construct,
+        construct: FlowConstruct,
         depth: u64,
-        chain: Vec<Construct>,
+        chain: Vec<FlowConstruct>,
     },
     Else,
     Logical {
@@ -237,7 +230,7 @@ impl ScoringContext<'_> {
         &mut self,
         node: tree_sitter::Node,
         nesting: u64,
-        construct: Construct,
+        construct: FlowConstruct,
     ) -> u64 {
         let increment = 1 + nesting;
         let kind = if nesting > 0 {
@@ -318,7 +311,7 @@ impl ScoringContext<'_> {
     }
 }
 
-fn nesting_chain(node: tree_sitter::Node, rules: &dyn LanguageRules) -> Vec<Construct> {
+fn nesting_chain(node: tree_sitter::Node, rules: &dyn LanguageRules) -> Vec<FlowConstruct> {
     let ancestors = std::iter::successors(node.parent(), tree_sitter::Node::parent);
     let mut chain = Vec::new();
     for ancestor in ancestors {
@@ -479,7 +472,10 @@ mod tests {
             contributors("fn f() { if true {} }"),
             vec![Contributor {
                 kind: ContributorKind::FlowBreak {
-                    construct: Construct::If,
+                    construct: FlowConstruct {
+                        role: Construct::Conditional,
+                        label: "if",
+                    },
                 },
                 line: 1,
                 increment: 1,
@@ -495,9 +491,21 @@ mod tests {
             cs[1],
             Contributor {
                 kind: ContributorKind::Nesting {
-                    construct: Construct::If,
+                    construct: FlowConstruct {
+                        role: Construct::Conditional,
+                        label: "if",
+                    },
                     depth: 1,
-                    chain: vec![Construct::For, Construct::If],
+                    chain: vec![
+                        FlowConstruct {
+                            role: Construct::Loop,
+                            label: "for"
+                        },
+                        FlowConstruct {
+                            role: Construct::Conditional,
+                            label: "if"
+                        },
+                    ],
                 },
                 line: 1,
                 increment: 2,
@@ -591,9 +599,21 @@ mod tests {
             nested,
             Some(&Contributor {
                 kind: ContributorKind::Nesting {
-                    construct: Construct::If,
+                    construct: FlowConstruct {
+                        role: Construct::Conditional,
+                        label: "if",
+                    },
                     depth: 2,
-                    chain: vec![Construct::Closure, Construct::If],
+                    chain: vec![
+                        FlowConstruct {
+                            role: Construct::InlineNesting,
+                            label: "closure"
+                        },
+                        FlowConstruct {
+                            role: Construct::Conditional,
+                            label: "if"
+                        },
+                    ],
                 },
                 line: 1,
                 increment: 3,


### PR DESCRIPTION
## Summary

- `Construct` now models cognitive complexity roles (`Conditional`, `Loop`, `ExceptionHandler`, `InlineNesting`) instead of Rust-specific syntax (`If`, `For`, `Match`, `Closure`)
- Each language provides its own display label via `FlowConstruct { role, label }`, so the scoring engine stays language-agnostic while evidence output remains specific (e.g. "if", "match", "switch")
- Preparatory step for TypeScript support

Part of #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)