### PR TITLE
refactor(code-complexity): clean up check.rs orchestration and tests

### DIFF
--- a/crates/scute-core/src/code_complexity/check.rs
+++ b/crates/scute-core/src/code_complexity/check.rs
@@ -72,20 +72,27 @@ pub fn check(
     let files = resolve_files(paths, definition)?;
     let languages = Languages::new();
 
-    let mut evaluations: Vec<Evaluation> = files
+    let evaluations: Vec<Evaluation> = files
         .iter()
         .filter_map(|path| std::fs::read_to_string(path).ok().map(|src| (path, src)))
         .flat_map(|(path, source)| score_file(path, &source, languages.for_path(path), &thresholds))
         .collect();
 
-    if evaluations.is_empty() {
-        let label = paths
-            .first()
-            .map_or_else(|| ".".into(), |p| p.display().to_string());
-        evaluations.push(Evaluation::completed(label, 0, thresholds, vec![]));
-    }
+    Ok(with_fallback(evaluations, paths, thresholds))
+}
 
-    Ok(evaluations)
+fn with_fallback(
+    evaluations: Vec<Evaluation>,
+    paths: &[PathBuf],
+    thresholds: Thresholds,
+) -> Vec<Evaluation> {
+    if !evaluations.is_empty() {
+        return evaluations;
+    }
+    let label = paths
+        .first()
+        .map_or_else(|| ".".into(), |p| p.display().to_string());
+    vec![Evaluation::completed(label, 0, thresholds, vec![])]
 }
 
 const SUPPORTED_EXTENSIONS: &[&str] = &["rs", "ts", "tsx"];


### PR DESCRIPTION
## Summary

- `check()` is now a 6-line orchestrator that delegates file resolution, language selection, scoring, and fallback handling
- Extracted `Languages` struct to encapsulate language rule selection by file extension
- Extracted `resolve_files()` and `with_fallback()` as focused helpers
- Renamed stale test name (`skips_non_rust_files` → `skips_unsupported_files`)
- Removed `scores_typescript_function` test (redundant with contract tests in `tests.rs` and acceptance tests)

Part of #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)