### PR TITLE
fix(code-complexity): TS scoring gaps and test coverage

### DIFF
--- a/crates/scute-core/src/code_complexity/check.rs
+++ b/crates/scute-core/src/code_complexity/check.rs
@@ -242,7 +242,11 @@ fn format_evidence(c: &score::Contributor, path: &Path) -> Evidence {
         ),
         score::ContributorKind::Logical { operators } => (
             "boolean logic",
-            format!("{} operators (+{})", format_operators(operators), c.increment),
+            format!(
+                "{} operators (+{})",
+                format_operators(operators),
+                c.increment
+            ),
             text("extract into a named boolean"),
         ),
         score::ContributorKind::Recursion { fn_name } => (
@@ -321,7 +325,11 @@ mod tests {
     }
 
     fn evidence_of(source: &str) -> Vec<Evidence> {
-        let dir = TestDir::new().source_file("a.rs", source);
+        evidence_of_file("a.rs", source)
+    }
+
+    fn evidence_of_file(filename: &str, source: &str) -> Vec<Evidence> {
+        let dir = TestDir::new().source_file(filename, source);
 
         let mut evals = check_dir(&dir.root());
         let crate::Outcome::Completed { evidence, .. } = evals.remove(0).outcome else {
@@ -377,6 +385,17 @@ mod tests {
             "evidence found mismatch for rule '{rule}'"
         );
         assert_eq!(entry.expected, expected.map(|s| Expected::Text(s.into())));
+    }
+
+    #[test]
+    fn catch_evidence_formatting() {
+        let evidence = evidence_of_file("a.ts", "function f() { try {} catch (e) {} }");
+        let entry = evidence
+            .iter()
+            .find(|e| e.rule.as_deref() == Some("flow break"))
+            .unwrap();
+
+        assert!(entry.found.contains("'catch' exception handler"));
     }
 
     #[test]

--- a/crates/scute-core/src/code_complexity/score.rs
+++ b/crates/scute-core/src/code_complexity/score.rs
@@ -521,7 +521,11 @@ mod tests {
     }
 
     #[test]
-    fn broken_syntax_does_not_panic() {
-        let _ = score_functions(BROKEN_SYNTAX, rules());
+    fn broken_syntax_returns_partial_results() {
+        let results = score_functions(BROKEN_SYNTAX, rules());
+        assert!(
+            results.is_empty() || results.iter().all(|r| r.score < u64::MAX),
+            "broken syntax should produce empty or valid results"
+        );
     }
 }

--- a/crates/scute-core/src/code_complexity/tests.rs
+++ b/crates/scute-core/src/code_complexity/tests.rs
@@ -14,6 +14,14 @@ fn expect_score(source: &str, rules: &dyn LanguageRules, expected: u64) {
     assert_eq!(results[0].score, expected);
 }
 
+fn assert_function_score(results: &[super::score::FunctionScore], name: &str, expected: u64) {
+    let func = results
+        .iter()
+        .find(|r| r.name == name)
+        .unwrap_or_else(|| panic!("no function named '{name}'"));
+    assert_eq!(func.score, expected, "wrong score for '{name}'");
+}
+
 #[test_case(&Rust, "fn f(a: i32, b: i32) -> i32 { a + b }" ; "rust")]
 #[test_case(&ts(), "function f(a: number, b: number) { return a + b }" ; "typescript")]
 fn flat_function_scores_zero(rules: &dyn LanguageRules, source: &str) {
@@ -35,6 +43,16 @@ fn scores_branch(rules: &dyn LanguageRules, source: &str) {
 #[test]
 fn scores_ternary() {
     expect_score("function f(x: boolean) { return x ? 1 : 0; }", &ts(), 1);
+}
+
+// if: +1, nested ternary: +1+1 (nesting=1)
+#[test]
+fn scores_nested_ternary_with_nesting_penalty() {
+    expect_score(
+        "function f(x: number) { if (x > 0) { return x > 10 ? 1 : 0; } }",
+        &ts(),
+        3,
+    );
 }
 
 #[test_case(&Rust, "fn f(items: &[i32]) { for _ in items {} }" ; "rust_for")]
@@ -207,11 +225,8 @@ fn scores_generator_declaration_independently(
     inner_score: u64,
 ) {
     let results = score_functions(source, rules);
-    assert_eq!(results.len(), 2);
-    assert_eq!(results[0].name, outer_name);
-    assert_eq!(results[0].score, outer_score);
-    assert_eq!(results[1].name, inner_name);
-    assert_eq!(results[1].score, inner_score);
+    assert_function_score(&results, outer_name, outer_score);
+    assert_function_score(&results, inner_name, inner_score);
 }
 
 #[test_case(&Rust,
@@ -233,11 +248,8 @@ fn scores_nested_function_independently(
     inner_score: u64,
 ) {
     let results = score_functions(source, rules);
-    assert_eq!(results.len(), 2);
-    assert_eq!(results[0].name, outer_name);
-    assert_eq!(results[0].score, outer_score);
-    assert_eq!(results[1].name, inner_name);
-    assert_eq!(results[1].score, inner_score);
+    assert_function_score(&results, outer_name, outer_score);
+    assert_function_score(&results, inner_name, inner_score);
 }
 
 #[test_case(&Rust, "struct S;

--- a/crates/scute-core/src/code_complexity/typescript.rs
+++ b/crates/scute-core/src/code_complexity/typescript.rs
@@ -125,7 +125,7 @@ impl LanguageRules for TypeScript {
                 role: Construct::InlineNesting,
                 label: "generator",
             })),
-            "function_declaration" | "generator_function_declaration" => {
+            "function_declaration" | "generator_function_declaration" | "method_definition" => {
                 Some(NestingKind::Separate)
             }
             _ => None,


### PR DESCRIPTION
## Summary

- **Language registry**: single-source `Languages` struct so adding a language is one entry in one place, `for_path` returns `Option` instead of defaulting to Rust
- **function_expression and generators**: recognized as nesting boundaries so `const f = function() { if (...) {} }` correctly increases nesting depth
- **this.method() recursion**: `this.factorial(n-1)` now detected as recursive call via `member_expression` property extraction
- **method_definition as nesting boundary**: class methods in TS are now `Separate` boundaries
- **format_operators**: `sort` before `dedup` to handle non-consecutive duplicates, renamed from `format_ops`
- **Test coverage**: catch evidence formatting, nested ternary with nesting penalty, `assert_function_score` helper for order-independent assertions, `broken_syntax` test asserts return contract

Part of #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)