### PR TITLE
docs(code-complexity): update docs for TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ your agent, and your CI all consume it identically.
 
 | Check                                                         | What it catches                        | Supports             |
 | ------------------------------------------------------------- | -------------------------------------- | -------------------- |
-| [`code-complexity`](docs/checks/code-complexity.md)           | Functions that are hard to understand  | Rust                 |
+| [`code-complexity`](docs/checks/code-complexity.md)           | Functions that are hard to understand  | Rust, TS             |
 | [`code-similarity`](docs/checks/code-similarity.md)           | Copy-paste and structural duplication  | Rust, JS, TS         |
 | [`commit-message`](docs/checks/commit-message.md)             | Sloppy or non-standard commit messages | Conventional commits |
 | [`dependency-freshness`](docs/checks/dependency-freshness.md) | Dependencies drifting behind           | Cargo, npm, pnpm     |
 
-JS/TS support for code-complexity is next. More checks and ecosystems are on
+JS support for code-complexity is next. More checks and ecosystems are on
 the [roadmap](handbook/roadmap.md).
 
 ## Install
@@ -230,7 +230,7 @@ For the full set of project values, see the [project handbook](handbook/).
 Early and moving fast. Four checks, CLI, MCP server, and structured output are
 shipping today.
 
-**Next:** code complexity for JS/TS, more package managers (Deno, Bun, Yarn),
+**Next:** code complexity for JS, more package managers (Deno, Bun, Yarn),
 trend tracking (delta-from-baseline, direction over time), new checks (circular
 dependencies, layer violations).
 

--- a/docs/checks/code-complexity.md
+++ b/docs/checks/code-complexity.md
@@ -23,19 +23,36 @@ Every function starts at 0. Six cognitive drivers add to the score:
 
 | Driver | Increment | When |
 | --- | --- | --- |
-| Flow break | +1 | `if`, `for`, `while`, `loop`, `match` at nesting depth 0 |
-| Nesting | +1 + depth | Same constructs, but nested inside other control flow |
+| Flow break | +1 | A control flow construct at nesting depth 0 |
+| Nesting | +1 + depth | A control flow construct nested inside other control flow |
 | Else | +1 | `else` or `else if` branch |
 | Boolean logic | +1 per sequence change | `a && b` = +1, `a && b \|\| c` = +2 |
 | Recursion | +1 | Direct recursive call |
 | Jump | +1 | Labeled `break` or `continue` |
 
-Key behaviors:
+### Language construct mapping
 
-- **Nesting multiplies.** An `if` inside a `for` inside a `match` costs 1 + nesting depth, not just 1. This is the main driver of high scores.
+Each language maps its own constructs to the cognitive drivers above.
+
+| Cognitive role | Rust | TypeScript |
+| --- | --- | --- |
+| Conditional | `if`, `match` | `if`, `switch`, ternary (`? :`) |
+| Loop | `for`, `while`, `loop` | `for`, `for...in`, `for...of`, `while`, `do...while` |
+| Exception handler | — | `catch` |
+| Else branch | `else` | `else` |
+| Boolean operator | `&&`, `\|\|` | `&&`, `\|\|` (nullish coalescing `??` is not scored) |
+| Inline nesting | closures | arrow functions, function expressions |
+| Jump | labeled `break`/`continue` | labeled `break`/`continue` |
+
+Constructs in the same cognitive role follow the same scoring rules. A `switch` in TypeScript scores exactly like a `match` in Rust.
+
+### Key behaviors
+
+- **Nesting multiplies.** An `if` inside a `for` inside a `match`/`switch` costs 1 + nesting depth, not just 1. This is the main driver of high scores.
 - **Else-if chains are flat.** `if / else if / else if / else` does not compound nesting. Each branch costs +1.
-- **Closures inherit nesting.** A closure bumps nesting depth by 1 for its contained code. It's not a fresh scope.
+- **Inline nesting inherits depth.** Closures (Rust) and arrow functions / function expressions (TS) bump nesting depth by 1 for their contained code. They're not a fresh scope.
 - **Logical operators count sequence changes.** `a && b && c` is one sequence (+1). `a && b || c && d` has two changes (+3).
+- **Ternaries score like `if`.** (TS) A ternary counts as a conditional and nests like any other flow construct.
 
 ## Usage
 
@@ -129,7 +146,7 @@ Each line that contributes to a function's score produces an evidence entry. The
 | `recursion` | `recursive call to 'process' (+1)` | consider iterative approach |
 | `jump` | `'break' to label 'outer (+1)` | restructure to avoid labeled jump |
 
-The nesting chain reads left-to-right (outside to inside) and stops at closure boundaries: `'if' nested 2 levels: 'closure > if' (+3)`.
+The nesting chain reads left-to-right (outside to inside) and stops at inline nesting boundaries: `'if' nested 2 levels: 'closure > if' (+3)` in Rust, `'if' nested 2 levels: 'arrow > if' (+3)` in TypeScript.
 
 ## Examples
 
@@ -200,7 +217,7 @@ All functions score within thresholds. Nothing to fix.
 
 ## Scope & limitations
 
-- **Supported languages:** Rust. TypeScript and JavaScript support is planned.
+- **Supported languages:** Rust and TypeScript. JavaScript support is planned.
 - **Per-function, not per-file.** Each function is evaluated and reported independently. The `target` includes the function name and line number.
 - **Structural, not semantic.** Measures control flow structure. Two functions that are equally hard to understand but use different constructs may score differently.
 - **Scoped analysis.** Only the files and directories you pass are analyzed. Pass nothing to scan the whole project.


### PR DESCRIPTION
## Summary

- Update README table: code-complexity now supports Rust, TS
- Update "coming next" blurbs to reference JS only (TS is shipped)
- Restructure scoring docs: language-agnostic driver table + construct mapping table per language
- Update scope section, key behaviors, and evidence examples for TS

🤖 Generated with [Claude Code](https://claude.com/claude-code)