### PR TITLE
fix(code-similarity): harden edge cases and writing style

### DIFF
--- a/crates/scute-core/src/code_similarity/detect.rs
+++ b/crates/scute-core/src/code_similarity/detect.rs
@@ -484,7 +484,7 @@ fn compute(
         let groups = detect_clones(&[a, b], LOW_TOKEN_THRESHOLD);
 
         // The suffix array finds many overlapping sub-sequences, but only
-        // the longest match should survive — shorter ones are fully contained.
+        // the longest match should survive. Shorter ones are fully contained.
         assert_eq!(groups.len(), 1);
     }
 }

--- a/crates/scute-core/src/code_similarity/parse.rs
+++ b/crates/scute-core/src/code_similarity/parse.rs
@@ -149,4 +149,20 @@ mod tests {
             .is_ok()
         );
     }
+
+    #[test]
+    fn syntax_errors_preserve_tokens_from_valid_parts() {
+        let tree = parse_source("fn valid() { 1 + 2 }\nfn broken(x: { }", "a.rs", &Rust).unwrap();
+        let tokens = tree.tokens();
+        let texts: Vec<&str> = tokens.iter().map(|t| t.text.as_str()).collect();
+
+        assert!(
+            texts.contains(&"fn"),
+            "valid tokens should survive syntax errors, got: {texts:?}"
+        );
+        assert!(
+            tokens.len() >= 5,
+            "expected several tokens from the valid part"
+        );
+    }
 }

--- a/crates/scute-core/src/code_similarity/tree.rs
+++ b/crates/scute-core/src/code_similarity/tree.rs
@@ -388,6 +388,11 @@ mod tests {
     }
 
     #[test]
+    fn all_share_contract_false_for_empty_pairs() {
+        assert!(!all_share_contract(&[]));
+    }
+
+    #[test]
     fn all_share_contract_false_when_no_overlap_in_multi_contract() {
         let tree_a = contract_tree("a.ts", &["Renderer", "Serializable"], &["fn", "$ID"]);
         let tree_b = contract_tree("b.ts", &["Formatter", "Disposable"], &["fn", "$ID"]);

--- a/handbook/pain-points.md
+++ b/handbook/pain-points.md
@@ -162,7 +162,7 @@ value.
   explore options or understand behavior, agent interprets it as a directive
   and starts making changes. Questions with question marks are for discussion,
   not action. Wait for explicit direction.
-- **Checklists skipped under momentum.** (×17) Established workflows and
+- **Checklists skipped under momentum.** (×18) Established workflows and
   checklists exist but get bypassed when focus is on "just get the thing done."
   The process is known, the trigger is clear, but urgency wins over discipline.
   Especially common with agents who optimize for task completion over process


### PR DESCRIPTION
## Summary

- Add ZOMBIES edge case tests: empty contract pairs, partial parse on syntax errors
- Fix em dash in test comment
- Bump pain-points counter for checklists skipped under momentum

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)