### PR TITLE
refactor(test-utils): typed DSL for commit-message check

### DIFF
--- a/crates/scute-cli/tests/acceptance.rs
+++ b/crates/scute-cli/tests/acceptance.rs
@@ -48,7 +48,8 @@ mod commit_message {
     #[test_case(Mcp)]
     fn valid_message_passes(interface: Interface) {
         Scute::new(interface)
-            .check(&["commit-message", "feat: add login"])
+            .commit_message("feat: add login")
+            .run()
             .expect_pass();
     }
 
@@ -57,7 +58,8 @@ mod commit_message {
     #[test_case(Mcp)]
     fn invalid_message_fails(interface: Interface) {
         Scute::new(interface)
-            .check(&["commit-message", "not conventional"])
+            .commit_message("not conventional")
+            .run()
             .expect_fail();
     }
 
@@ -66,7 +68,8 @@ mod commit_message {
     #[test_case(Mcp)]
     fn invalid_message_shows_subject_line_as_target(interface: Interface) {
         Scute::new(interface)
-            .check(&["commit-message", "not conventional"])
+            .commit_message("not conventional")
+            .run()
             .expect_target("not conventional");
     }
 
@@ -82,7 +85,8 @@ checks:
     types: [hotfix]
 ",
             )
-            .check(&["commit-message", "hotfix: urgent patch"])
+            .commit_message("hotfix: urgent patch")
+            .run()
             .expect_pass();
     }
 
@@ -91,7 +95,8 @@ checks:
     #[test_case(Mcp)]
     fn passing_check_omits_evidence(interface: Interface) {
         Scute::new(interface)
-            .check(&["commit-message", "feat: add login"])
+            .commit_message("feat: add login")
+            .run()
             .expect_pass()
             .expect_no_findings();
     }
@@ -427,7 +432,8 @@ mod config {
     fn malformed_config_produces_error(interface: Interface) {
         Scute::new(interface)
             .scute_config("not: valid: yaml: [")
-            .check(&["commit-message", "feat: add login"])
+            .commit_message("feat: add login")
+            .run()
             .expect_error("invalid_config");
     }
 
@@ -436,7 +442,8 @@ mod config {
     fn empty_config_uses_defaults(interface: Interface) {
         Scute::new(interface)
             .scute_config("")
-            .check(&["commit-message", "feat: add login"])
+            .commit_message("feat: add login")
+            .run()
             .expect_pass();
     }
 
@@ -452,7 +459,8 @@ checks:
       types: [hotfix]
 ",
             )
-            .check(&["commit-message", "hotfix: urgent patch"])
+            .commit_message("hotfix: urgent patch")
+            .run()
             .expect_error("invalid_config");
     }
 
@@ -468,7 +476,8 @@ checks:
 ",
             )
             .cwd("nested")
-            .check(&["commit-message", "hotfix: urgent patch"])
+            .commit_message("hotfix: urgent patch")
+            .run()
             .expect_pass();
     }
 }

--- a/crates/scute-cli/tests/cli.rs
+++ b/crates/scute-cli/tests/cli.rs
@@ -3,6 +3,7 @@ use scute_test_utils::Scute;
 #[test]
 fn stdin_provides_commit_message_as_target() {
     Scute::cli_stdin()
-        .check(&["commit-message", "not conventional"])
+        .commit_message("not conventional")
+        .run()
         .expect_target("not conventional");
 }

--- a/crates/scute-test-utils/src/cli.rs
+++ b/crates/scute-test-utils/src/cli.rs
@@ -2,23 +2,14 @@ use std::path::Path;
 
 use tempfile::TempDir;
 
-use crate::{Backend, CheckResult, ExitStatus, ListChecksResult, target_bin};
+use crate::{Backend, CheckInput, CheckResult, ExitStatus, ListChecksResult, target_bin};
 
 pub(crate) struct CliBackend {
     pub(crate) stdin: bool,
 }
 
-impl Backend for CliBackend {
-    fn check(&self, dir: TempDir, working_dir: &Path, args: &[&str]) -> CheckResult {
-        let mut cmd = assert_cmd::Command::new(target_bin("scute"));
-        cmd.current_dir(working_dir);
-        if self.stdin {
-            let message = args.last().expect("CliStdin requires message in args");
-            cmd.args(&args[..args.len() - 1])
-                .write_stdin(message.to_string());
-        } else {
-            cmd.args(args);
-        }
+impl CliBackend {
+    fn run_cmd(mut cmd: assert_cmd::Command, dir: TempDir, working_dir: &Path) -> CheckResult {
         let output = cmd.output().unwrap();
         let exit_code = output.status.code().unwrap_or(-1);
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -37,6 +28,37 @@ impl Backend for CliBackend {
             debug_info: format!("exit: {exit_code}\nstderr: {stderr}"),
             _dir: dir,
         }
+    }
+}
+
+impl Backend for CliBackend {
+    fn check(&self, dir: TempDir, working_dir: &Path, args: &[&str]) -> CheckResult {
+        let mut cmd = assert_cmd::Command::new(target_bin("scute"));
+        cmd.current_dir(working_dir);
+        if self.stdin {
+            let message = args.last().expect("CliStdin requires message in args");
+            cmd.args(&args[..args.len() - 1])
+                .write_stdin(message.to_string());
+        } else {
+            cmd.args(args);
+        }
+        Self::run_cmd(cmd, dir, working_dir)
+    }
+
+    fn run_check(&self, dir: TempDir, working_dir: &Path, input: &CheckInput) -> CheckResult {
+        let mut cmd = assert_cmd::Command::new(target_bin("scute"));
+        cmd.current_dir(working_dir);
+        match input {
+            CheckInput::CommitMessage { message } => {
+                if self.stdin {
+                    cmd.args(["check", "commit-message"])
+                        .write_stdin(message.clone());
+                } else {
+                    cmd.args(["check", "commit-message", message]);
+                }
+            }
+        }
+        Self::run_cmd(cmd, dir, working_dir)
     }
 
     fn list_checks(&self, dir: TempDir) -> ListChecksResult {

--- a/crates/scute-test-utils/src/lib.rs
+++ b/crates/scute-test-utils/src/lib.rs
@@ -90,8 +90,20 @@ impl std::fmt::Display for Interface {
     }
 }
 
+/// Typed check parameters. Each variant maps to a check's inputs.
+///
+/// To add a new check:
+/// 1. Add a variant here with the check's parameters
+/// 2. Add a constructor on [`Scute`] that takes mandatory params and returns a builder
+/// 3. Put optional params as builder methods, `.run()` executes
+/// 4. Implement the variant in both backends' `run_check`
+pub(crate) enum CheckInput {
+    CommitMessage { message: String },
+}
+
 trait Backend {
     fn check(&self, dir: TempDir, working_dir: &Path, args: &[&str]) -> CheckResult;
+    fn run_check(&self, dir: TempDir, working_dir: &Path, input: &CheckInput) -> CheckResult;
     fn list_checks(&self, dir: TempDir) -> ListChecksResult;
 }
 
@@ -160,6 +172,13 @@ impl Scute {
         self
     }
 
+    pub fn commit_message(self, message: &str) -> CommitMessageCheck {
+        CommitMessageCheck {
+            scute: self,
+            message: message.into(),
+        }
+    }
+
     pub fn list_checks(self) -> ListChecksResult {
         let dir = self.project.build();
         self.backend.list_checks(dir)
@@ -169,15 +188,38 @@ impl Scute {
         let mut full_args = vec!["check"];
         full_args.extend_from_slice(args);
         let dir = self.project.build();
-        let working_dir = match &self.cwd {
-            Some(subdir) => {
-                let path = dir.path().join(subdir);
-                std::fs::create_dir_all(&path).expect("failed to create cwd subdir");
-                path
-            }
-            None => dir.path().to_path_buf(),
-        };
+        let working_dir = resolve_working_dir(&dir, self.cwd.as_deref());
         self.backend.check(dir, &working_dir, &full_args)
+    }
+
+    fn run_check(self, input: &CheckInput) -> CheckResult {
+        let dir = self.project.build();
+        let working_dir = resolve_working_dir(&dir, self.cwd.as_deref());
+        self.backend.run_check(dir, &working_dir, input)
+    }
+}
+
+fn resolve_working_dir(dir: &TempDir, cwd: Option<&str>) -> PathBuf {
+    match cwd {
+        Some(subdir) => {
+            let path = dir.path().join(subdir);
+            std::fs::create_dir_all(&path).expect("failed to create cwd subdir");
+            path
+        }
+        None => dir.path().to_path_buf(),
+    }
+}
+
+pub struct CommitMessageCheck {
+    scute: Scute,
+    message: String,
+}
+
+impl CommitMessageCheck {
+    pub fn run(self) -> CheckResult {
+        self.scute.run_check(&CheckInput::CommitMessage {
+            message: self.message,
+        })
     }
 }
 

--- a/crates/scute-test-utils/src/mcp.rs
+++ b/crates/scute-test-utils/src/mcp.rs
@@ -12,19 +12,20 @@ use rmcp::{
 use tempfile::TempDir;
 use tokio::process::Command;
 
-use crate::{Backend, CheckResult, ExitStatus, ListChecksResult, target_bin};
+use crate::{Backend, CheckInput, CheckResult, ExitStatus, ListChecksResult, target_bin};
 
 pub(crate) struct McpBackend;
 
-impl Backend for McpBackend {
-    fn check(&self, dir: TempDir, working_dir: &Path, args: &[&str]) -> CheckResult {
-        let check_name = args.get(1).expect("check name required");
-        let tool_name = format!("check_{}", check_name.replace('-', "_"));
-        let tool_args = build_tool_args(check_name, &args[2..]);
+impl McpBackend {
+    fn call(
+        dir: TempDir,
+        working_dir: &Path,
+        tool_name: &str,
+        tool_args: &serde_json::Value,
+    ) -> CheckResult {
         let project_dir = working_dir.canonicalize().unwrap();
-
         let client = McpTestClient::connect(&project_dir);
-        let result = client.call_tool(&tool_name, &tool_args);
+        let result = client.call_tool(tool_name, tool_args);
 
         let json = result
             .structured_content
@@ -47,6 +48,25 @@ impl Backend for McpBackend {
             exit_status,
             debug_info,
         }
+    }
+}
+
+impl Backend for McpBackend {
+    fn check(&self, dir: TempDir, working_dir: &Path, args: &[&str]) -> CheckResult {
+        let check_name = args.get(1).expect("check name required");
+        let tool_name = format!("check_{}", check_name.replace('-', "_"));
+        let tool_args = build_tool_args(check_name, &args[2..]);
+        Self::call(dir, working_dir, &tool_name, &tool_args)
+    }
+
+    fn run_check(&self, dir: TempDir, working_dir: &Path, input: &CheckInput) -> CheckResult {
+        let (tool_name, tool_args) = match input {
+            CheckInput::CommitMessage { message } => (
+                "check_commit_message",
+                serde_json::json!({ "message": message }),
+            ),
+        };
+        Self::call(dir, working_dir, tool_name, &tool_args)
     }
 
     fn list_checks(&self, dir: TempDir) -> ListChecksResult {


### PR DESCRIPTION
## Summary

- Replace string-based `.check(&["commit-message", "msg"])` with typed `.commit_message("msg").run()` builder
- Add `CheckInput` enum as the typed boundary between builders and backends
- Each backend (CLI, MCP) maps from `CheckInput` directly, no `build_tool_args` bridging for commit-message
- Extract shared helpers (`run_cmd`, `call`, `resolve_working_dir`) to reduce duplication between old and new paths
- Migrate all commit-message and config module tests to the new API

Convention for future checks: mandatory params go in the constructor, optional params are builder methods, `.run()` executes. Documented on `CheckInput`.

Part of #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)