### PR TITLE
refactor(test-utils): typed DSL for all checks, remove string-based API

### DIFF
--- a/crates/scute-cli/tests/acceptance.rs
+++ b/crates/scute-cli/tests/acceptance.rs
@@ -112,7 +112,8 @@ mod dependency_freshness {
     #[test_case(Mcp)]
     fn fresh_project_passes(interface: Interface) {
         Scute::new(interface)
-            .check(&["dependency-freshness"])
+            .dependency_freshness()
+            .run()
             .expect_pass();
     }
 
@@ -121,7 +122,8 @@ mod dependency_freshness {
     fn outdated_deps_fail(interface: Interface) {
         Scute::new(interface)
             .dependency("itoa", "=0.4.8")
-            .check(&["dependency-freshness"])
+            .dependency_freshness()
+            .run()
             .expect_fail();
     }
 
@@ -129,7 +131,9 @@ mod dependency_freshness {
     #[test_case(Mcp)]
     fn nonexistent_path_produces_error(interface: Interface) {
         Scute::new(interface)
-            .check(&["dependency-freshness", "/nonexistent/path"])
+            .dependency_freshness()
+            .path("/nonexistent/path")
+            .run()
             .expect_error("invalid_target");
     }
 
@@ -139,7 +143,9 @@ mod dependency_freshness {
         let dir = TestProject::empty().build();
 
         Scute::new(interface)
-            .check(&["dependency-freshness", dir.path().to_str().unwrap()])
+            .dependency_freshness()
+            .path(dir.path().to_str().unwrap())
+            .run()
             .expect_error("invalid_target");
     }
 
@@ -156,7 +162,8 @@ checks:
       fail: 5
 ",
             )
-            .check(&["dependency-freshness"])
+            .dependency_freshness()
+            .run()
             .expect_pass();
     }
 
@@ -174,7 +181,8 @@ checks:
       fail: 5
 ",
             )
-            .check(&["dependency-freshness"])
+            .dependency_freshness()
+            .run()
             .expect_warn();
     }
 }
@@ -200,7 +208,8 @@ checks:
     min-tokens: 5
 ",
             )
-            .check(&["code-similarity"])
+            .code_similarity()
+            .run()
             .expect_fail();
     }
 
@@ -221,7 +230,8 @@ checks:
       - 'b.rs'
 ",
             )
-            .check(&["code-similarity"])
+            .code_similarity()
+            .run()
             .expect_pass();
     }
 
@@ -229,7 +239,9 @@ checks:
     #[test_case(Mcp)]
     fn nonexistent_source_dir_produces_error(interface: Interface) {
         Scute::new(interface)
-            .check(&["code-similarity", "--source-dir", "/nonexistent/path"])
+            .code_similarity()
+            .source_dir("/nonexistent/path")
+            .run()
             .expect_error("invalid_target");
     }
 
@@ -250,7 +262,9 @@ checks:
     min-tokens: 5
 ",
             )
-            .check(&["code-similarity", "a.rs"])
+            .code_similarity()
+            .files(&["a.rs"])
+            .run()
             .expect_fail()
             .expect_finding_count(1)
             .expect_target_contains("a.rs");
@@ -292,7 +306,8 @@ checks:
 ",
             )
             .source_file("src/complex.rs", COMPLEX_SOURCE)
-            .check(&["code-complexity"])
+            .code_complexity()
+            .run()
     }
 
     #[test_case(Cli)]
@@ -317,7 +332,8 @@ checks:
     fn simple_rust_function_passes(interface: Interface) {
         Scute::new(interface)
             .source_file("src/simple.rs", "fn add(a: i32, b: i32) -> i32 { a + b }")
-            .check(&["code-complexity"])
+            .code_complexity()
+            .run()
             .expect_pass();
     }
 
@@ -335,7 +351,8 @@ checks:
       fail: 30
 ",
             )
-            .check(&["code-complexity"])
+            .code_complexity()
+            .run()
             .expect_pass();
     }
 
@@ -354,7 +371,8 @@ checks:
       - 'src/complex.rs'
 ",
             )
-            .check(&["code-complexity"])
+            .code_complexity()
+            .run()
             .expect_pass();
     }
 
@@ -389,7 +407,8 @@ function process(items: number[]): number {
 }
 ",
             )
-            .check(&["code-complexity"])
+            .code_complexity()
+            .run()
             .expect_warn()
             .expect_target_contains("process");
     }
@@ -398,7 +417,9 @@ function process(items: number[]): number {
     #[test_case(Mcp)]
     fn nonexistent_path_produces_error(interface: Interface) {
         Scute::new(interface)
-            .check(&["code-complexity", "/nonexistent/path"])
+            .code_complexity()
+            .paths(&["/nonexistent/path"])
+            .run()
             .expect_error("invalid_target");
     }
 
@@ -416,7 +437,9 @@ checks:
       warn: 1
 ",
             )
-            .check(&["code-complexity", "src/simple.rs"])
+            .code_complexity()
+            .paths(&["src/simple.rs"])
+            .run()
             .expect_pass();
     }
 }

--- a/crates/scute-test-utils/src/cli.rs
+++ b/crates/scute-test-utils/src/cli.rs
@@ -31,32 +31,42 @@ impl CliBackend {
     }
 }
 
-impl Backend for CliBackend {
-    fn check(&self, dir: TempDir, working_dir: &Path, args: &[&str]) -> CheckResult {
-        let mut cmd = assert_cmd::Command::new(target_bin("scute"));
-        cmd.current_dir(working_dir);
-        if self.stdin {
-            let message = args.last().expect("CliStdin requires message in args");
-            cmd.args(&args[..args.len() - 1])
-                .write_stdin(message.to_string());
-        } else {
-            cmd.args(args);
+fn cli_args(input: &CheckInput) -> Vec<String> {
+    match input {
+        CheckInput::CommitMessage { message } => {
+            vec!["check".into(), "commit-message".into(), message.clone()]
         }
-        Self::run_cmd(cmd, dir, working_dir)
+        CheckInput::DependencyFreshness { path } => {
+            let mut args = vec!["check".into(), "dependency-freshness".into()];
+            args.extend(path.iter().cloned());
+            args
+        }
+        CheckInput::CodeComplexity { paths } => {
+            let mut args = vec!["check".into(), "code-complexity".into()];
+            args.extend(paths.iter().cloned());
+            args
+        }
+        CheckInput::CodeSimilarity { source_dir, files } => {
+            let mut args = vec!["check".into(), "code-similarity".into()];
+            if let Some(dir) = source_dir {
+                args.extend(["--source-dir".into(), dir.clone()]);
+            }
+            args.extend(files.iter().cloned());
+            args
+        }
     }
+}
 
+impl Backend for CliBackend {
     fn run_check(&self, dir: TempDir, working_dir: &Path, input: &CheckInput) -> CheckResult {
         let mut cmd = assert_cmd::Command::new(target_bin("scute"));
         cmd.current_dir(working_dir);
-        match input {
-            CheckInput::CommitMessage { message } => {
-                if self.stdin {
-                    cmd.args(["check", "commit-message"])
-                        .write_stdin(message.clone());
-                } else {
-                    cmd.args(["check", "commit-message", message]);
-                }
-            }
+        let args = cli_args(input);
+        if self.stdin {
+            let stdin_input = args.last().expect("check must have args").clone();
+            cmd.args(&args[..args.len() - 1]).write_stdin(stdin_input);
+        } else {
+            cmd.args(&args);
         }
         Self::run_cmd(cmd, dir, working_dir)
     }

--- a/crates/scute-test-utils/src/lib.rs
+++ b/crates/scute-test-utils/src/lib.rs
@@ -98,11 +98,22 @@ impl std::fmt::Display for Interface {
 /// 3. Put optional params as builder methods, `.run()` executes
 /// 4. Implement the variant in both backends' `run_check`
 pub(crate) enum CheckInput {
-    CommitMessage { message: String },
+    CommitMessage {
+        message: String,
+    },
+    DependencyFreshness {
+        path: Option<String>,
+    },
+    CodeComplexity {
+        paths: Vec<String>,
+    },
+    CodeSimilarity {
+        source_dir: Option<String>,
+        files: Vec<String>,
+    },
 }
 
 trait Backend {
-    fn check(&self, dir: TempDir, working_dir: &Path, args: &[&str]) -> CheckResult;
     fn run_check(&self, dir: TempDir, working_dir: &Path, input: &CheckInput) -> CheckResult;
     fn list_checks(&self, dir: TempDir) -> ListChecksResult;
 }
@@ -179,17 +190,31 @@ impl Scute {
         }
     }
 
+    pub fn dependency_freshness(self) -> DependencyFreshnessCheck {
+        DependencyFreshnessCheck {
+            scute: self,
+            path: None,
+        }
+    }
+
+    pub fn code_complexity(self) -> CodeComplexityCheck {
+        CodeComplexityCheck {
+            scute: self,
+            paths: Vec::new(),
+        }
+    }
+
+    pub fn code_similarity(self) -> CodeSimilarityCheck {
+        CodeSimilarityCheck {
+            scute: self,
+            source_dir: None,
+            files: Vec::new(),
+        }
+    }
+
     pub fn list_checks(self) -> ListChecksResult {
         let dir = self.project.build();
         self.backend.list_checks(dir)
-    }
-
-    pub fn check(self, args: &[&str]) -> CheckResult {
-        let mut full_args = vec!["check"];
-        full_args.extend_from_slice(args);
-        let dir = self.project.build();
-        let working_dir = resolve_working_dir(&dir, self.cwd.as_deref());
-        self.backend.check(dir, &working_dir, &full_args)
     }
 
     fn run_check(self, input: &CheckInput) -> CheckResult {
@@ -219,6 +244,65 @@ impl CommitMessageCheck {
     pub fn run(self) -> CheckResult {
         self.scute.run_check(&CheckInput::CommitMessage {
             message: self.message,
+        })
+    }
+}
+
+pub struct DependencyFreshnessCheck {
+    scute: Scute,
+    path: Option<String>,
+}
+
+impl DependencyFreshnessCheck {
+    pub fn path(mut self, path: &str) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    pub fn run(self) -> CheckResult {
+        self.scute
+            .run_check(&CheckInput::DependencyFreshness { path: self.path })
+    }
+}
+
+pub struct CodeComplexityCheck {
+    scute: Scute,
+    paths: Vec<String>,
+}
+
+impl CodeComplexityCheck {
+    pub fn paths(mut self, paths: &[&str]) -> Self {
+        self.paths = paths.iter().map(|s| (*s).into()).collect();
+        self
+    }
+
+    pub fn run(self) -> CheckResult {
+        self.scute
+            .run_check(&CheckInput::CodeComplexity { paths: self.paths })
+    }
+}
+
+pub struct CodeSimilarityCheck {
+    scute: Scute,
+    source_dir: Option<String>,
+    files: Vec<String>,
+}
+
+impl CodeSimilarityCheck {
+    pub fn source_dir(mut self, dir: &str) -> Self {
+        self.source_dir = Some(dir.into());
+        self
+    }
+
+    pub fn files(mut self, files: &[&str]) -> Self {
+        self.files = files.iter().map(|s| (*s).into()).collect();
+        self
+    }
+
+    pub fn run(self) -> CheckResult {
+        self.scute.run_check(&CheckInput::CodeSimilarity {
+            source_dir: self.source_dir,
+            files: self.files,
         })
     }
 }

--- a/crates/scute-test-utils/src/mcp.rs
+++ b/crates/scute-test-utils/src/mcp.rs
@@ -52,20 +52,8 @@ impl McpBackend {
 }
 
 impl Backend for McpBackend {
-    fn check(&self, dir: TempDir, working_dir: &Path, args: &[&str]) -> CheckResult {
-        let check_name = args.get(1).expect("check name required");
-        let tool_name = format!("check_{}", check_name.replace('-', "_"));
-        let tool_args = build_tool_args(check_name, &args[2..]);
-        Self::call(dir, working_dir, &tool_name, &tool_args)
-    }
-
     fn run_check(&self, dir: TempDir, working_dir: &Path, input: &CheckInput) -> CheckResult {
-        let (tool_name, tool_args) = match input {
-            CheckInput::CommitMessage { message } => (
-                "check_commit_message",
-                serde_json::json!({ "message": message }),
-            ),
-        };
+        let (tool_name, tool_args) = mcp_tool_call(input);
         Self::call(dir, working_dir, tool_name, &tool_args)
     }
 
@@ -162,46 +150,42 @@ impl ClientHandler for RootsProvider {
     }
 }
 
-fn build_tool_args(check_name: &str, args: &[&str]) -> serde_json::Value {
-    match check_name {
-        "commit-message" => {
-            let message = args.first().copied().unwrap_or("");
-            serde_json::json!({ "message": message })
-        }
-        "code-complexity" => positional_paths_args("paths", args),
-        "code-similarity" => source_files_args(args),
-        "dependency-freshness" => match args.first() {
-            Some(path) => serde_json::json!({ "path": path }),
-            None => serde_json::json!({}),
-        },
-        _ => serde_json::json!({}),
-    }
+fn json_object(entries: &[(&str, Option<serde_json::Value>)]) -> serde_json::Value {
+    serde_json::Value::Object(
+        entries
+            .iter()
+            .filter_map(|(k, v)| v.as_ref().map(|v| ((*k).into(), v.clone())))
+            .collect(),
+    )
 }
 
-fn positional_paths_args(key: &str, args: &[&str]) -> serde_json::Value {
-    match args.first() {
-        Some(_) => serde_json::json!({ key: args }),
-        None => serde_json::json!({}),
-    }
+fn non_empty(slice: &[String]) -> Option<serde_json::Value> {
+    (!slice.is_empty()).then(|| serde_json::json!(slice))
 }
 
-fn source_files_args(args: &[&str]) -> serde_json::Value {
-    let mut json = serde_json::Map::new();
-    let mut files = Vec::new();
-    let mut i = 0;
-    while i < args.len() {
-        if args[i] == "--source-dir"
-            && let Some(val) = args.get(i + 1)
-        {
-            json.insert("source_dir".into(), serde_json::json!(val));
-            i += 2;
-            continue;
-        }
-        files.push(args[i]);
-        i += 1;
+fn mcp_tool_call(input: &CheckInput) -> (&'static str, serde_json::Value) {
+    match input {
+        CheckInput::CommitMessage { message } => (
+            "check_commit_message",
+            serde_json::json!({ "message": message }),
+        ),
+        CheckInput::DependencyFreshness { path } => (
+            "check_dependency_freshness",
+            json_object(&[("path", path.as_ref().map(|p| serde_json::json!(p)))]),
+        ),
+        CheckInput::CodeComplexity { paths } => (
+            "check_code_complexity",
+            json_object(&[("paths", non_empty(paths))]),
+        ),
+        CheckInput::CodeSimilarity { source_dir, files } => (
+            "check_code_similarity",
+            json_object(&[
+                (
+                    "source_dir",
+                    source_dir.as_ref().map(|d| serde_json::json!(d)),
+                ),
+                ("files", non_empty(files)),
+            ]),
+        ),
     }
-    if !files.is_empty() {
-        json.insert("files".into(), serde_json::json!(files));
-    }
-    serde_json::Value::Object(json)
 }

--- a/handbook/pain-points.md
+++ b/handbook/pain-points.md
@@ -185,10 +185,11 @@ value.
   context but treated as reference material instead of active capabilities.
   Agents follow static lists instead of thinking "what tools do I have for
   this?"
-- **Dismissed own tool warnings on freshly written code.** Pre-commit hook
-  flagged 108-token duplication between code just written and code just moved.
-  The agent rationalized it as "expected cost of separate compilation units"
-  instead of treating it as a signal to fix the design.
+- **Dismissed own tool warnings on freshly written code.** (×2) Pre-commit hook
+  flags an issue on code the agent just wrote, and the agent rationalizes why
+  it's acceptable ("inherent to the function's job", "expected cost of separate
+  compilation units") instead of treating it as a signal to fix the design.
+  If the tool warns on code you just wrote, try to fix it before dismissing.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Migrate dependency-freshness, code-complexity, and code-similarity to typed builders
- Remove `Backend::check(&[&str])`, `Scute::check()`, `build_tool_args`, and all bridging helpers
- Each check now follows the convention: `check_name(mandatory).optional().run()`
- Extract `cli_args()` and `mcp_tool_call()` to keep backend implementations flat

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)