### PR TITLE
feat(code-complexity): add JavaScript support

### DIFF
--- a/crates/scute-core/src/code_complexity/check.rs
+++ b/crates/scute-core/src/code_complexity/check.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use super::rules::LanguageRules;
-use super::{rust, score, typescript};
+use super::{javascript, rust, score};
 use crate::files;
 use crate::{Evaluation, Evidence, ExecutionError, Expected, Thresholds};
 
@@ -121,16 +121,16 @@ fn languages() -> crate::files::LanguageRegistry<dyn LanguageRules> {
             rules: Box::new(rust::Rust),
         },
         LanguageRegistryEntry {
+            extensions: &["js", "jsx", "mjs", "cjs"],
+            rules: Box::new(javascript::JsFamily::javascript()),
+        },
+        LanguageRegistryEntry {
             extensions: &["ts"],
-            rules: Box::new(typescript::TypeScript::new(
-                tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-            )),
+            rules: Box::new(javascript::JsFamily::typescript()),
         },
         LanguageRegistryEntry {
             extensions: &["tsx"],
-            rules: Box::new(typescript::TypeScript::new(
-                tree_sitter_typescript::LANGUAGE_TSX.into(),
-            )),
+            rules: Box::new(javascript::JsFamily::typescript_tsx()),
         },
     ])
 }
@@ -360,9 +360,10 @@ mod tests {
         assert_eq!(entry.expected, expected.map(|s| Expected::Text(s.into())));
     }
 
-    #[test]
-    fn catch_evidence_formatting() {
-        let evidence = evidence_of_file("a.ts", "function f() { try {} catch (e) {} }");
+    #[test_case("a.ts" ; "typescript")]
+    #[test_case("a.js" ; "javascript")]
+    fn catch_evidence_formatting(filename: &str) {
+        let evidence = evidence_of_file(filename, "function f() { try {} catch (e) {} }");
         let entry = evidence
             .iter()
             .find(|e| e.rule.as_deref() == Some("flow break"))
@@ -428,17 +429,32 @@ mod tests {
         assert!(evals[0].target.contains("Greeting"));
     }
 
+    #[test_case("app.js" ; "js")]
+    #[test_case("app.jsx" ; "jsx")]
+    #[test_case("app.mjs" ; "mjs")]
+    #[test_case("app.cjs" ; "cjs")]
+    fn scores_javascript_file(filename: &str) {
+        let dir = TestDir::new().source_file(filename, "function greet() { return 'hi' }");
+
+        let evals = check_dir(&dir.root());
+
+        assert_eq!(evals.len(), 1);
+        assert!(evals[0].target.contains("greet"));
+    }
+
     #[test]
     fn scores_mixed_language_project() {
         let dir = TestDir::new()
             .source_file("lib.rs", "fn rust_fn() { if true {} }")
-            .source_file("app.ts", "function ts_fn() { return 1 }");
+            .source_file("app.ts", "function ts_fn() { return 1 }")
+            .source_file("util.js", "function js_fn() { return 2 }");
 
         let evals = check_dir(&dir.root());
 
-        assert_eq!(evals.len(), 2);
+        assert_eq!(evals.len(), 3);
         let names: Vec<&str> = evals.iter().map(|e| e.target.as_str()).collect();
         assert!(names.iter().any(|t| t.contains("rust_fn")));
         assert!(names.iter().any(|t| t.contains("ts_fn")));
+        assert!(names.iter().any(|t| t.contains("js_fn")));
     }
 }

--- a/crates/scute-core/src/code_complexity/javascript.rs
+++ b/crates/scute-core/src/code_complexity/javascript.rs
@@ -3,17 +3,35 @@ use tree_sitter::Language;
 use super::rules::{LanguageRules, NestingKind, ScoringUnit};
 use super::score::{Construct, FlowConstruct, JumpKeyword, LogicalOp};
 
-pub struct TypeScript {
+pub struct JsFamily {
     language: Language,
 }
 
-impl TypeScript {
-    pub fn new(language: Language) -> Self {
-        Self { language }
+/// Covers JavaScript, TypeScript, and TSX (parameterized by grammar).
+impl JsFamily {
+    #[must_use]
+    pub fn javascript() -> Self {
+        Self {
+            language: tree_sitter_javascript::LANGUAGE.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn typescript() -> Self {
+        Self {
+            language: tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn typescript_tsx() -> Self {
+        Self {
+            language: tree_sitter_typescript::LANGUAGE_TSX.into(),
+        }
     }
 }
 
-impl LanguageRules for TypeScript {
+impl LanguageRules for JsFamily {
     fn language(&self) -> Language {
         self.language.clone()
     }

--- a/crates/scute-core/src/code_complexity/mod.rs
+++ b/crates/scute-core/src/code_complexity/mod.rs
@@ -25,11 +25,11 @@
 //! [`Evidence`](crate::Evidence) entries explaining what drives the score.
 
 mod check;
+mod javascript;
 mod rules;
 mod rust;
 mod score;
 #[cfg(test)]
 mod tests;
-mod typescript;
 
 pub use check::{CHECK_NAME, Definition, check};

--- a/crates/scute-core/src/code_complexity/tests.rs
+++ b/crates/scute-core/src/code_complexity/tests.rs
@@ -1,11 +1,15 @@
+use super::javascript::JsFamily;
 use super::rules::LanguageRules;
 use super::rust::Rust;
 use super::score::score_functions;
-use super::typescript::TypeScript;
 use test_case::test_case;
 
-fn ts() -> TypeScript {
-    TypeScript::new(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
+fn js() -> JsFamily {
+    JsFamily::javascript()
+}
+
+fn ts() -> JsFamily {
+    JsFamily::typescript()
 }
 
 fn expect_score(source: &str, rules: &dyn LanguageRules, expected: u64) {
@@ -200,33 +204,29 @@ fn scores_inline_nesting(rules: &dyn LanguageRules, source: &str) {
 
 // function expression: const f = function() {...}
 // nesting +1, if: +1+1, else: +1
-#[test_case(&ts(), "function f() {
+#[test]
+fn scores_function_expression_as_inline_nesting() {
+    expect_score(
+        "function f() {
     const g = function() {
         if (true) { return 1; }
         else { return 0; }
     };
-}" ; "typescript_function_expression")]
-fn scores_function_expression_as_inline_nesting(rules: &dyn LanguageRules, source: &str) {
-    expect_score(source, rules, 3);
+}",
+        &ts(),
+        3,
+    );
 }
 
 // generator declaration: behaves like nested named function (Separate)
-#[test_case(&ts(),
-    "function outer() { function* gen() { if (true) {} } if (true) {} }",
-    "outer", 3, "gen", 1
-    ; "typescript_generator"
-)]
-fn scores_generator_declaration_independently(
-    rules: &dyn LanguageRules,
-    source: &str,
-    outer_name: &str,
-    outer_score: u64,
-    inner_name: &str,
-    inner_score: u64,
-) {
-    let results = score_functions(source, rules);
-    assert_function_score(&results, outer_name, outer_score);
-    assert_function_score(&results, inner_name, inner_score);
+#[test]
+fn scores_generator_declaration_independently() {
+    let results = score_functions(
+        "function outer() { function* gen() { if (true) {} } if (true) {} }",
+        &ts(),
+    );
+    assert_function_score(&results, "outer", 3);
+    assert_function_score(&results, "gen", 1);
 }
 
 #[test_case(&Rust,
@@ -287,5 +287,28 @@ fn ignores_non_this_member_call_as_recursion() {
         }",
         &ts(),
         2,
+    );
+}
+
+// JS grammar smoke test: exercises all construct families through the JS parser
+// to verify grammar wiring. Scoring logic is shared with TS and tested above.
+#[test]
+fn javascript_grammar_scores_all_constructs() {
+    // for...of: +1, if: +1+1(nesting), nested if: +1+2(nesting),
+    // &&: +1, break outer: +1, else: +1, recursion: +1 = 10
+    expect_score(
+        "function process(items) {
+            outer: for (const item of items) {
+                if (item > 0) {
+                    if (item > 10 && item < 100) {
+                        break outer;
+                    }
+                } else {
+                    return process(items.slice(1));
+                }
+            }
+        }",
+        &js(),
+        10,
     );
 }

--- a/handbook/pain-points.md
+++ b/handbook/pain-points.md
@@ -162,7 +162,7 @@ value.
   explore options or understand behavior, agent interprets it as a directive
   and starts making changes. Questions with question marks are for discussion,
   not action. Wait for explicit direction.
-- **Checklists skipped under momentum.** (×18) Established workflows and
+- **Checklists skipped under momentum.** (×19) Established workflows and
   checklists exist but get bypassed when focus is on "just get the thing done."
   The process is known, the trigger is clear, but urgency wins over discipline.
   Especially common with agents who optimize for task completion over process


### PR DESCRIPTION
## Summary

- Extend cognitive complexity scoring to JavaScript files (`.js`, `.jsx`, `.mjs`, `.cjs`)
- Rename `TypeScript` module to `JsFamily` with named constructors (`javascript()`, `typescript()`, `typescript_tsx()`), matching the `code-similarity` check pattern
- JS and TS share identical tree-sitter node types, so the same scoring rules apply with no JS-specific logic needed

Part of #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)