### PR TITLE
test(code-similarity): cover import exclusion edge cases

### DIFF
--- a/crates/scute-core/src/code_similarity/javascript.rs
+++ b/crates/scute-core/src/code_similarity/javascript.rs
@@ -256,6 +256,7 @@ mod tests {
     #[test_case("import { foo } from 'bar';", "a.tsx" ; "tsx named import")]
     #[test_case("import foo from 'bar';", "a.ts" ; "default import")]
     #[test_case("import * as foo from 'bar';", "a.ts" ; "namespace import")]
+    #[test_case("import './polyfill';", "a.ts" ; "side effect import")]
     fn strips_import_statements(source: &str, path: &str) {
         let (_, tokens) = parse_file(source, path);
         assert!(tokens.is_empty(), "expected no tokens, got: {tokens:?}");
@@ -263,7 +264,10 @@ mod tests {
 
     #[test]
     fn preserves_code_after_imports() {
-        let (_, tokens) = parse_file("import { foo } from 'bar';\nconst x = 1;", "a.ts");
+        let (_, tokens) = parse_file(
+            "import { foo } from 'bar';\nimport { baz } from 'qux';\nconst x = 1;",
+            "a.ts",
+        );
         assert_eq!(token_texts(&tokens), vec!["const", "$ID", "=", "$LIT", ";"]);
     }
 


### PR DESCRIPTION
## Summary

- Adds side-effect import test case (`import './polyfill'`)
- Expands `preserves_code_after_imports` to use multiple imports before code

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)