### PR TITLE
chore(deps): upgrade rmcp to 1.4

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -954,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.1.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4950422f87cf98fffc36946ad672c3024750b3c301491599715b7d6497dfbc"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64",
@@ -978,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.1.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9a2cbdcc704fa56c3fe79c681bd8f739d77c68ede3a670faeb6df50f836874"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -8,7 +8,7 @@ pedantic = { level = "warn", priority = -1 }
 [workspace.dependencies]
 googletest = "0.14.2"
 test-case = "3"
-rmcp = "1.1"
+rmcp = "1.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/scute-mcp/src/lib.rs
+++ b/crates/scute-mcp/src/lib.rs
@@ -9,7 +9,6 @@ use std::path::{Path, PathBuf};
 
 use rmcp::{
     ErrorData, RoleServer, ServerHandler, ServiceExt,
-    handler::server::router::tool::ToolRouter,
     handler::server::tool::schema_for_output,
     handler::server::wrapper::Parameters,
     model::{CallToolResult, ServerCapabilities, ServerInfo},
@@ -63,17 +62,7 @@ struct CheckSourceFilesInput {
 }
 
 #[derive(Debug, Clone)]
-struct ScuteMcp {
-    tool_router: ToolRouter<Self>,
-}
-
-impl ScuteMcp {
-    fn new() -> Self {
-        Self {
-            tool_router: Self::tool_router(),
-        }
-    }
-}
+struct ScuteMcp;
 
 #[tool_router]
 impl ScuteMcp {
@@ -298,7 +287,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let service = ScuteMcp::new().serve(stdio()).await?;
+        let service = ScuteMcp.serve(stdio()).await?;
         service.waiting().await?;
         Ok(())
     })


### PR DESCRIPTION
## Summary

- Upgrades `rmcp` from 1.1 to 1.4 in the workspace
- Removes the now-unused `tool_router` field from `ScuteMcp` (the macros handle routing internally since 1.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)